### PR TITLE
Add PowerShell helpers for dependency reuse and config bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,129 @@
+# 🧠 HomeSky — Agents Overview
+
+This document describes the **build, ingest, and visualization agents** used during development and deployment of *HomeSky*, plus how Codex presents their logs and status so you can follow along easily.
+
+## 1️⃣ Agent Roles
+
+### A. Build Agent  
+Handles dependency installs, environment setup, and build automation.  
+Typical commands:  
+- `python -m pip install -r requirements.txt`  
+- `python ingest.py --once`  
+- `streamlit run visualize_streamlit.py`  
+- `pyinstaller --onefile --noconsole -n HomeSky gui.py`
+
+**Codex window behavior:**  
+Shows “Installing dependencies…” and package logs; `[Running HomeSky: ingest.py]` headers during script runs; ends with a visible build artifact path (e.g., `dist/HomeSky.exe`).
+
+### B. Ingest Agent  
+Connects to the Ambient Weather API, detects cadence, writes new samples to SQLite/Parquet.  
+Codex logs lines like:  
+`[HomeSky][Ingest] New record inserted: 2025-10-04T14:23Z` and `Cadence ≈ 602s (stable)`.  
+Skips duplicates gracefully and retries failed requests.  
+
+**Common-sense cues:**  
+Repeated timestamps → station hasn’t posted yet.  
+JSON errors → check API keys.
+
+### C. Visualization Agent  
+Runs Streamlit dashboard.  
+Codex shows “You can now view your Streamlit app…” with an **Open in new tab** button.  
+Blank charts = no data yet or wrong range.  
+“Disconnected” = refresh tab.
+
+### D. GUI Launcher Agent  
+PySimpleGUI helper for quick actions (Fetch, Open Dashboard, Logs).  
+Codex prints `[GUI launched]` message when simulated in headless mode.
+
+---
+
+## 2️⃣ Expected Codex Window Updates
+
+| Stage | Example Message | Meaning |
+|-------|-----------------|----------|
+| 🏗️ Setup | Installing dependencies | pip installs libraries |
+| 🌦️ Ingest | `[HomeSky][Ingest] Fetching…` | API request running |
+| 💾 Write | `Inserted 1 record` | Data appended successfully |
+| 📉 Dashboard | `Streamlit running at :8501` | Visualization active |
+| ⚠️ Warning | `Duplicate timestamp skipped` | Normal duplicate handling |
+| ❌ Error | `401 Unauthorized` | Check credentials |
+
+Look for `[HomeSky]` prefixes in logs to distinguish app messages from system noise.
+
+---
+
+## 3️⃣ Local Workflow
+
+```
+python ingest.py
+streamlit run visualize_streamlit.py
+pyinstaller --onefile --noconsole -n HomeSky gui.py
+```
+
+Logs → `data/logs/ingest.log`  
+Database → `data/homesky.sqlite`
+
+---
+
+## 4️⃣ Common-Sense UI Updates
+
+| Element | Behavior | Why |
+|----------|-----------|----|
+| Spinner | Appears during fetch | Confirms progress |
+| Chart fade-in | Smooth transitions | Prevents jarring redraws |
+| Auto-refresh | 60-s default | Mirrors station cadence |
+| “Stale” badge | API delay | Graceful error |
+| Toast “Exported CSV” | Confirms save | User feedback |
+
+---
+
+## 5️⃣ Troubleshooting
+
+| Symptom | Cause | Fix |
+|----------|-------|----|
+| 401 Unauthorized | Wrong key | Update config.toml |
+| No new data | Station offline | Check Ambient site |
+| Empty dashboard | Bad date filter | Reset range |
+| Duplicate spam | Repeated dateutc | Wait; station delay |
+| SQLite locked | Folder permissions | Move data dir |
+
+---
+
+## 6️⃣ Codex for New Users
+- **Codex terminal = live console.** Watch the right pane for `[HomeSky]` logs.  
+- **Stop** with the red ■ button; logs persist.  
+- **Restart** to resume the loop.  
+- **Streamlit** may auto-reload; `[rerun]` lines are normal.  
+
+✅ File location: `/HomeSky/Agents.md`  
+✅ Maintainer: Alex Balog — THG Geophysics  
+✅ Purpose: Quick reference for Codex and local debugging.
+
+---
+
+# 🌤️ README Excerpt Update
+
+## HomeSky
+
+Local weather station dashboard and long-term data collector built for the Ambient Weather WS-2000.
+
+**Docs overview:**
+- `Agents.md` → explains how Codex agents and the Streamlit GUI behave.  
+- `config.example.toml` → fill in your Ambient API keys and station MAC.  
+- `ingest.py` → background collector.  
+- `visualize_streamlit.py` → dashboard app.  
+- `gui.py` → simple desktop launcher.
+
+**Quick start:**
+1. Copy `config.example.toml` → `config.toml`
+2. Add your Ambient `apiKey` and `applicationKey`
+3. Run:
+   ```
+   python ingest.py
+   streamlit run visualize_streamlit.py
+   ```
+4. Optional: package into EXE  
+   `pyinstaller --onefile --noconsole -n HomeSky gui.py`
+
+**Troubleshooting:**  
+See `Agents.md` for detailed logs, agent roles, and Codex terminal expectations.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # HomeSky
 single-user Windows desktop app for Ambient Weather station with long-term capture, Dark-Sky-style visuals, and rich exports (web-ready later)
+
+### Run locally or build fast
+
+> Use the helper scripts in `/tools` to reuse your virtual environment and skip dependency reinstalls unless `requirements.txt` changes.  They also take care of the PySimpleGUI private index and bootstrap a config file if it does not exist yet.
+
+```pwsh
+# Clean refresh or first clone
+cd %USERPROFILE%\Desktop
+if (Test-Path .\HomeSky) { cd .\HomeSky; git fetch origin; git reset --hard origin/main; git clean -xfd } else { git clone https://github.com/Balooog/HomeSky.git; cd .\HomeSky }
+
+# Dev run (fast; reuses .venv; installs only if requirements changed)
+.\tools\ensure_venv_and_deps.ps1
+.\tools\ensure_config.ps1
+python .\homesky\gui.py
+
+# --- or, when you want an EXE ---
+.\tools\ensure_venv_and_deps.ps1
+pip install -r dev-requirements.txt
+python -m PyInstaller --onefile --clean --name HomeSky --distpath dist homesky\gui.py
+
+# Test Build Complete
+```

--- a/build_exe.ps1
+++ b/build_exe.ps1
@@ -1,0 +1,5 @@
+# build_exe.ps1 — package EXE using existing venv; installs deps only when changed
+.\tools\ensure_venv_and_deps.ps1
+pip install -r dev-requirements.txt
+python -m PyInstaller --onefile --clean --name HomeSky --distpath dist homesky\gui.py
+Write-Host "# Test Build Complete" -ForegroundColor Green

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,1 @@
+pyinstaller>=6.6

--- a/homesky/.gitignore
+++ b/homesky/.gitignore
@@ -1,0 +1,8 @@
+config.toml
+data/
+logs/
+*.pyc
+__pycache__/
+.build/
+dist/
+.streamlit/

--- a/homesky/README.md
+++ b/homesky/README.md
@@ -1,0 +1,64 @@
+# HomeSky
+
+HomeSky is a Dark Sky–inspired personal weather hub for Ambient Weather stations. It pairs a lightweight
+long-running ingest service with a Streamlit dashboard and a tiny PySimpleGUI launcher so a single power user can
+capture, explore, and export rich weather history on Windows. The project is written for Python 3.11+ and is designed
+for packaging into a standalone executable via PyInstaller or similar tools.
+
+## Features
+
+- **Long-term capture** – `ingest.py` continuously polls the Ambient Weather Network (AWN) REST API and stores
+  observations in SQLite and append-only Parquet files.
+- **Fast, beautiful visualization** – `visualize_streamlit.py` provides Dark-Sky-style charts with resampling, derived
+  metrics, and export helpers.
+- **Desktop first, web ready** – `gui.py` offers Fetch/Open helpers for a Windows desktop workflow, while the Streamlit
+  app can be hosted separately with minimal changes.
+- **Rich exports** – CSV and Parquet exports are available directly from the dashboard, and data is organized under a
+  configurable storage root for other tooling.
+
+## Getting started
+
+1. Install Python 3.11 or newer.
+2. Create and activate a virtual environment.
+3. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+4. Copy `config.example.toml` to `config.toml` and edit it with your Ambient Weather API credentials and preferences.
+5. Run the ingest service:
+   ```bash
+   python ingest.py
+   ```
+   Use `python ingest.py --once` for a single polling cycle (for Task Scheduler or testing).
+6. In another terminal, launch the dashboard:
+   ```bash
+   streamlit run visualize_streamlit.py
+   ```
+7. (Optional) Launch the desktop helper:
+   ```bash
+   python gui.py
+   ```
+
+## Packaging on Windows
+
+Use PyInstaller or Briefcase to bundle `gui.py` into a single-file executable. The included `packaging/run_dashboard.bat`
+script shows how to start the Streamlit dashboard pointing to the project directory. When packaging, include the `assets`
+folder and ensure the `config.toml` and `data` directory are located in a writable location, such as `%APPDATA%/HomeSky`.
+
+## Data layout
+
+The ingest service respects the `storage` settings in `config.toml`. By default it creates:
+
+- `data/homesky.sqlite` – canonical observations table.
+- `data/homesky.parquet` – append-only Parquet log for analytical tooling.
+- `data/logs/ingest.log` – rotating log managed by Loguru.
+
+## Development tips
+
+- Use `explain.py` to print configuration and environment status for troubleshooting.
+- Use the `sample_scheduler_task.xml` as a template for Windows Task Scheduler if you prefer to run ingest on an interval.
+- Extend `utils/derived.py` to add new calculated metrics; they automatically appear in the dashboard when registered.
+
+## License
+
+This project is released under the MIT License. See `../LICENSE` for details.

--- a/homesky/config.example.toml
+++ b/homesky/config.example.toml
@@ -1,0 +1,46 @@
+[ambient]
+api_key = "YOUR_API_KEY"
+application_key = "YOUR_APPLICATION_KEY"
+mac = ""  # optional; if multiple stations, set a specific MAC
+
+[storage]
+root_dir = "./data"
+sqlite_path = "./data/homesky.sqlite"
+parquet_path = "./data/homesky.parquet"
+
+[timezone]
+local_tz = "America/New_York"
+
+[units]
+temperature = "F"  # F or C
+wind = "mph"       # mph or mps
+rain = "in"        # in or mm
+
+[derived]
+hdd_base_f = 65
+cdd_base_f = 65
+enable_wetbulb = true
+enable_vpd = true
+enable_wind_run = true
+
+[ingest]
+deduplicate_by_timestamp = true
+drop_implausible_values = true
+log_path = "./data/logs/ingest.log"
+log_rotate_days = 14
+max_retries = 3
+retry_backoff_sec = 10
+
+[visualization]
+default_metric = "temp_f"
+default_resample = "H"
+default_aggregate = "mean"
+theme = "dark"  # dark | light | system
+
+[alerts]
+enabled = false
+temp_high_f = 95
+temp_low_f = 10
+gust_high_mph = 45
+hourly_rain_in = 0.5
+quiet_hours_local = "22:00-07:00"

--- a/homesky/explain.py
+++ b/homesky/explain.py
@@ -1,0 +1,42 @@
+"""Diagnostic helper for HomeSky."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+import ingest
+from utils.db import DatabaseManager
+
+console = Console()
+
+
+def main() -> None:
+    try:
+        config = ingest.load_config()
+    except FileNotFoundError:
+        console.print("[bold red]config.toml missing[/bold red]")
+        return
+
+    console.print("[bold cyan]HomeSky Configuration[/bold cyan]")
+    console.print_json(json.dumps(config))
+
+    storage = config.get("storage", {})
+    db = DatabaseManager(Path(storage.get("sqlite_path", "./data/homesky.sqlite")), Path(storage.get("parquet_path", "./data/homesky.parquet")))
+    last = db.fetch_last_timestamp(config.get("ambient", {}).get("mac"))
+
+    table = Table(title="Storage", box=box.ROUNDED)
+    table.add_column("Resource")
+    table.add_column("Path")
+    table.add_row("SQLite", str(db.sqlite_path))
+    table.add_row("Parquet", str(db.parquet_path))
+    table.add_row("Last Observation UTC", str(last or "None"))
+    console.print(table)
+
+
+if __name__ == "__main__":
+    main()

--- a/homesky/gui.py
+++ b/homesky/gui.py
@@ -1,0 +1,125 @@
+"""PySimpleGUI helper launcher for HomeSky."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import PySimpleGUI as sg
+
+import ingest
+from utils.db import DatabaseManager
+
+PACKAGE_DIR = Path(__file__).resolve().parent
+CONFIG_EXAMPLE = PACKAGE_DIR / "config.example.toml"
+CONFIG_TARGETS = [Path("config.toml"), PACKAGE_DIR / "config.toml"]
+
+
+def bootstrap_config_file() -> Path:
+    for candidate in CONFIG_TARGETS:
+        if candidate.exists():
+            return candidate
+    target = CONFIG_TARGETS[-1]
+    if CONFIG_EXAMPLE.exists():
+        target.write_text(CONFIG_EXAMPLE.read_text(), encoding="utf-8")
+    else:
+        stub = (
+            "[ambient]\n"
+            "api_key = \"\"\n"
+            "application_key = \"\"\n"
+            "mac = \"\"\n\n"
+            "[storage]\n"
+            "root_dir = \"./data\"\n"
+            "sqlite_path = \"./data/homesky.sqlite\"\n"
+            "parquet_path = \"./data/homesky.parquet\"\n"
+        )
+        target.write_text(stub, encoding="utf-8")
+    return target
+
+
+def load_config() -> dict:
+    return ingest.load_config()
+
+
+def open_path(path: Path) -> None:
+    if sys.platform.startswith("win"):
+        os.startfile(path)  # type: ignore[attr-defined]
+    elif sys.platform == "darwin":  # pragma: no cover
+        subprocess.Popen(["open", str(path)])
+    else:
+        subprocess.Popen(["xdg-open", str(path)])
+
+
+def run_streamlit() -> subprocess.Popen:
+    return subprocess.Popen([sys.executable, "-m", "streamlit", "run", "visualize_streamlit.py"])
+
+
+def main() -> None:
+    sg.theme("DarkGrey9")
+    try:
+        config = load_config()
+    except FileNotFoundError:
+        created_path = bootstrap_config_file()
+        sg.popup_ok(
+            "Missing config.toml. A starter file has been created at\n"
+            f"{created_path.resolve()}\n\nUpdate your Ambient Weather credentials and relaunch HomeSky.",
+            title="HomeSky configuration required",
+        )
+        return
+    ingest.setup_logging(config)
+    storage = config.get("storage", {})
+    data_dir = Path(storage.get("root_dir", "./data")).resolve()
+    sqlite_path = Path(storage.get("sqlite_path", "./data/homesky.sqlite"))
+    parquet_path = Path(storage.get("parquet_path", "./data/homesky.parquet"))
+
+    layout = [
+        [sg.Text("HomeSky Control", font=("Inter", 16))],
+        [sg.Button("Fetch Now", key="fetch", size=(20, 1))],
+        [sg.Button("Open Dashboard", key="dashboard", size=(20, 1))],
+        [sg.Button("Open Data Folder", key="data", size=(20, 1))],
+        [sg.Button("View Logs", key="logs", size=(20, 1))],
+        [sg.Multiline(size=(60, 10), key="log", autoscroll=True, disabled=True)],
+        [sg.Button("Exit")],
+    ]
+
+    window = sg.Window("HomeSky", layout, finalize=True)
+
+    dashboard_process: subprocess.Popen | None = None
+    db = DatabaseManager(sqlite_path, parquet_path)
+
+    while True:
+        event, values = window.read(timeout=100)
+        if event in (sg.WIN_CLOSED, "Exit"):
+            break
+        if event == "fetch":
+            try:
+                inserted = ingest.ingest_once(config, db)
+                window["log"].update(f"Fetched {inserted} new rows\n", append=True)
+            except Exception as exc:  # pragma: no cover
+                window["log"].update(f"Error: {exc}\n", append=True)
+        elif event == "dashboard":
+            if dashboard_process and dashboard_process.poll() is None:
+                window["log"].update("Dashboard already running\n", append=True)
+            else:
+                dashboard_process = run_streamlit()
+                window["log"].update("Launching Streamlit dashboard...\n", append=True)
+        elif event == "data":
+            data_dir.mkdir(parents=True, exist_ok=True)
+            open_path(data_dir)
+            window["log"].update(f"Opened data folder at {data_dir}\n", append=True)
+        elif event == "logs":
+            log_path = Path(config.get("ingest", {}).get("log_path", "./data/logs/ingest.log")).resolve()
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            open_path(log_path if log_path.exists() else log_path.parent)
+            window["log"].update(f"Opened log path {log_path}\n", append=True)
+
+    if dashboard_process and dashboard_process.poll() is None:
+        dashboard_process.terminate()
+
+    window.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/homesky/ingest.py
+++ b/homesky/ingest.py
@@ -1,0 +1,190 @@
+"""Long-running Ambient Weather ingest service."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+from loguru import logger
+
+from utils.ambient import AmbientClient
+from utils.db import DatabaseManager
+from utils.derived import compute_all_derived
+
+try:
+    import tomllib  # Python 3.11+
+except ImportError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+
+CONFIG_PATHS = [Path("config.toml"), Path("homesky/config.toml")]
+
+
+def load_config(path: Path | None = None) -> Dict:
+    candidates = [path] if path else CONFIG_PATHS
+    for candidate in candidates:
+        if candidate and candidate.exists():
+            with candidate.open("rb") as fh:
+                return tomllib.load(fh)
+    raise FileNotFoundError(
+        "config.toml not found. Run tools/ensure_config.ps1 or copy homesky/config.example.toml to homesky/config.toml and populate your credentials."
+    )
+
+
+def setup_logging(config: Dict) -> None:
+    log_path = Path(config.get("ingest", {}).get("log_path", "./data/logs/ingest.log"))
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    rotation_days = config.get("ingest", {}).get("log_rotate_days", 14)
+    logger.remove()
+    logger.add(sys.stderr, level="INFO")
+    logger.add(
+        log_path,
+        rotation=f"{rotation_days} days",
+        retention=f"{rotation_days * 2} days",
+        level="DEBUG",
+        backtrace=True,
+        enqueue=True,
+    )
+    logger.info("Logging initialized at %s", log_path)
+
+
+def flatten_observations(records: List[Dict]) -> pd.DataFrame:
+    rows: List[Dict] = []
+    for device in records:
+        last = device.get("lastData", {})
+        if not last:
+            continue
+        row = {**last}
+        row["mac"] = device.get("macAddress") or device.get("mac")
+        if "dateutc" in row:
+            dateutc = row["dateutc"]
+            if isinstance(dateutc, (int, float)):
+                row["obs_time_utc"] = pd.to_datetime(dateutc, unit="ms", errors="coerce", utc=True)
+            else:
+                row["obs_time_utc"] = pd.to_datetime(dateutc, errors="coerce", utc=True)
+        if "date" in row:
+            row["obs_time_local"] = pd.to_datetime(row["date"], errors="coerce")
+        row["raw"] = last
+        rows.append(row)
+    if not rows:
+        return pd.DataFrame()
+    frame = pd.DataFrame(rows)
+    if "obs_time_utc" in frame:
+        frame = frame.sort_values("obs_time_utc")
+        frame = frame.set_index("obs_time_utc")
+    return frame
+
+
+def deduplicate(df: pd.DataFrame, db: DatabaseManager, mac: str | None, enabled: bool) -> pd.DataFrame:
+    if df.empty or not enabled:
+        return df
+    latest = db.fetch_last_timestamp(mac)
+    if not latest:
+        return df
+    mask = df.index > pd.to_datetime(latest, utc=True)
+    return df.loc[mask]
+
+
+def detect_cadence_seconds(df: pd.DataFrame) -> int:
+    if df.empty or "epoch" not in df:
+        return 60
+    epochs = pd.to_numeric(df["epoch"], errors="coerce").dropna()
+    if epochs.empty:
+        return 60
+    diffs = epochs.diff().dropna()
+    if diffs.empty:
+        return 60
+    cadence = int(diffs.median())
+    return max(cadence, 60)
+
+
+def drop_implausible(df: pd.DataFrame) -> pd.DataFrame:
+    if df.empty:
+        return df
+    mask = pd.Series(True, index=df.index)
+    if "tempf" in df:
+        mask &= df["tempf"].between(-80, 150)
+    if "windspeedmph" in df:
+        mask &= df["windspeedmph"].between(0, 200)
+    if "humidity" in df:
+        mask &= df["humidity"].between(0, 100)
+    return df.loc[mask]
+
+
+def ingest_once(config: Dict, db: DatabaseManager) -> int:
+    client = AmbientClient(
+        api_key=config["ambient"]["api_key"],
+        application_key=config["ambient"]["application_key"],
+        mac=config["ambient"].get("mac") or None,
+        retries=config.get("ingest", {}).get("max_retries", 3),
+        backoff=config.get("ingest", {}).get("retry_backoff_sec", 10),
+    )
+    records = client.get_device_data(limit=288)
+    frame = flatten_observations(records)
+    if config.get("ingest", {}).get("drop_implausible_values", True):
+        frame = drop_implausible(frame)
+    frame = deduplicate(
+        frame,
+        db,
+        mac=config["ambient"].get("mac") or None,
+        enabled=config.get("ingest", {}).get("deduplicate_by_timestamp", True),
+    )
+    if frame.empty:
+        logger.info("No new observations to ingest.")
+        return 0
+    records_for_db = frame.reset_index().to_dict(orient="records")
+    inserted = db.insert_observations(records_for_db)
+    enriched = compute_all_derived(frame.drop(columns=["raw"], errors="ignore"), config)
+    db.append_parquet(enriched)
+    logger.info("Ingested %d new observation rows", inserted)
+    return inserted
+
+
+def run_loop(config: Dict, db: DatabaseManager) -> None:
+    poll_seconds = 60
+    while True:
+        try:
+            inserted = ingest_once(config, db)
+        except KeyboardInterrupt:
+            logger.info("Ingest loop interrupted by user")
+            raise
+        except Exception as exc:  # pragma: no cover
+            logger.exception("Ingest failed: %s", exc)
+        else:
+            if inserted:
+                poll_seconds = detect_cadence_seconds(db.read_dataframe(limit=10))
+        logger.info("Sleeping for %s seconds", poll_seconds)
+        time.sleep(poll_seconds)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="HomeSky ingest service")
+    parser.add_argument("--once", action="store_true", help="Run a single ingest cycle and exit")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = load_config()
+    setup_logging(config)
+    logger.info("Starting HomeSky ingest service")
+    storage = config.get("storage", {})
+    db = DatabaseManager(
+        sqlite_path=Path(storage.get("sqlite_path", "./data/homesky.sqlite")),
+        parquet_path=Path(storage.get("parquet_path", "./data/homesky.parquet")),
+    )
+    try:
+        if args.once:
+            ingest_once(config, db)
+        else:
+            run_loop(config, db)
+    except KeyboardInterrupt:
+        logger.info("Shutdown requested. Exiting.")
+
+
+if __name__ == "__main__":
+    main()

--- a/homesky/packaging/run_dashboard.bat
+++ b/homesky/packaging/run_dashboard.bat
@@ -1,0 +1,5 @@
+@echo off
+REM Launch the HomeSky Streamlit dashboard
+set SCRIPT_DIR=%~dp0..
+cd /d %SCRIPT_DIR%
+streamlit run visualize_streamlit.py --server.headless=false

--- a/homesky/packaging/sample_scheduler_task.xml
+++ b/homesky/packaging/sample_scheduler_task.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <Triggers>
+    <CalendarTrigger>
+      <StartBoundary>2024-01-01T00:00:00</StartBoundary>
+      <Enabled>true</Enabled>
+      <ScheduleByDay>
+        <DaysInterval>1</DaysInterval>
+      </ScheduleByDay>
+    </CalendarTrigger>
+  </Triggers>
+  <Principals>
+    <Principal id="Author">
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>HighestAvailable</RunLevel>
+    </Principal>
+  </Principals>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <AllowHardTerminate>false</AllowHardTerminate>
+    <StartWhenAvailable>true</StartWhenAvailable>
+    <RunOnlyIfNetworkAvailable>true</RunOnlyIfNetworkAvailable>
+    <IdleSettings>
+      <StopOnIdleEnd>false</StopOnIdleEnd>
+      <RestartOnIdle>false</RestartOnIdle>
+    </IdleSettings>
+    <AllowStartOnDemand>true</AllowStartOnDemand>
+    <Enabled>true</Enabled>
+    <Hidden>false</Hidden>
+    <RunOnlyIfIdle>false</RunOnlyIfIdle>
+    <WakeToRun>false</WakeToRun>
+    <ExecutionTimeLimit>PT30M</ExecutionTimeLimit>
+    <Priority>7</Priority>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>python</Command>
+      <Arguments>homesky\ingest.py --once</Arguments>
+      <WorkingDirectory>%APPDATA%\HomeSky</WorkingDirectory>
+    </Exec>
+  </Actions>
+</Task>

--- a/homesky/requirements.txt
+++ b/homesky/requirements.txt
@@ -1,0 +1,14 @@
+requests==2.31.0
+pandas==2.2.3
+pyarrow==15.0.2
+python-dateutil==2.9.0.post0
+pytz==2024.1
+streamlit==1.37.0
+PySimpleGUI==4.60.5
+matplotlib==3.8.4
+numpy==1.26.4
+scipy==1.11.4
+humanize==4.9.0
+loguru==0.7.2
+rich==13.7.1
+altair==5.2.0

--- a/homesky/utils/__init__.py
+++ b/homesky/utils/__init__.py
@@ -1,0 +1,18 @@
+"""Utility helpers for HomeSky."""
+
+from .ambient import AmbientClient, get_devices, fetch_latest_observations
+from .db import DatabaseManager, ensure_schema
+from .derived import compute_all_derived, register_derived_metric
+from .theming import get_theme, load_typography
+
+__all__ = [
+    "AmbientClient",
+    "get_devices",
+    "fetch_latest_observations",
+    "DatabaseManager",
+    "ensure_schema",
+    "compute_all_derived",
+    "register_derived_metric",
+    "get_theme",
+    "load_typography",
+]

--- a/homesky/utils/ambient.py
+++ b/homesky/utils/ambient.py
@@ -1,0 +1,106 @@
+"""Ambient Weather Network client helpers."""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
+import requests
+from loguru import logger
+
+BASE_URL = "https://api.ambientweather.net/v1"
+
+
+class AmbientAPIError(RuntimeError):
+    """Raised when the Ambient Weather Network API returns an error."""
+
+
+@dataclass(slots=True)
+class AmbientClient:
+    """Thin wrapper around the Ambient Weather Network REST API."""
+
+    api_key: str
+    application_key: str
+    mac: Optional[str] = None
+    session: Optional[requests.Session] = None
+    retries: int = 3
+    backoff: float = 5.0
+
+    def _request(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+        if not self.api_key or not self.application_key:
+            raise AmbientAPIError("API key and application key are required")
+
+        payload = {
+            "apiKey": self.api_key,
+            "applicationKey": self.application_key,
+        }
+        if params:
+            payload.update(params)
+        if self.mac:
+            payload.setdefault("macAddress", self.mac)
+
+        session = self.session or requests.Session()
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                response = session.get(f"{BASE_URL}/{path}", params=payload, timeout=30)
+                if response.status_code >= 400:
+                    raise AmbientAPIError(
+                        f"Ambient API error {response.status_code}: {response.text}"
+                    )
+                return response.json()
+            except (requests.RequestException, AmbientAPIError) as exc:  # pragma: no cover
+                if attempt >= self.retries:
+                    logger.error("Ambient API request failed after {} attempts", attempt)
+                    raise
+                sleep_for = self.backoff * attempt
+                logger.warning(
+                    "Ambient API request failed (attempt %s/%s): %s; retrying in %.1fs",
+                    attempt,
+                    self.retries,
+                    exc,
+                    sleep_for,
+                )
+                time.sleep(sleep_for)
+
+    def get_devices(self) -> List[Dict[str, Any]]:
+        """Return the list of devices bound to the API keys."""
+
+        devices = self._request("devices")
+        if not isinstance(devices, list):
+            raise AmbientAPIError("Unexpected devices payload")
+        if self.mac:
+            devices = [device for device in devices if device.get("macAddress") == self.mac]
+        logger.debug("Fetched %d devices from Ambient Weather", len(devices))
+        return devices
+
+    def get_device_data(self, limit: int = 288) -> List[Dict[str, Any]]:
+        """Fetch recent observations for the configured device(s)."""
+
+        params: Dict[str, Any] = {"limit": limit}
+        data = self._request("devices", params=params)
+        if not isinstance(data, list):
+            raise AmbientAPIError("Unexpected observations payload")
+        logger.debug("Fetched %d observation rows", len(data))
+        return data
+
+
+def get_devices(api_key: str, app_key: str, mac: str | None = None) -> List[Dict[str, Any]]:
+    """Convenience function to retrieve device metadata."""
+
+    client = AmbientClient(api_key=api_key, application_key=app_key, mac=mac)
+    return client.get_devices()
+
+
+def fetch_latest_observations(
+    api_key: str,
+    app_key: str,
+    mac: str | None = None,
+    limit: int = 288,
+) -> List[Dict[str, Any]]:
+    """Fetch latest observations for downstream ingestion."""
+
+    client = AmbientClient(api_key=api_key, application_key=app_key, mac=mac)
+    return client.get_device_data(limit=limit)

--- a/homesky/utils/charts.py
+++ b/homesky/utils/charts.py
@@ -1,0 +1,69 @@
+"""Chart helpers for Streamlit."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+import altair as alt
+import pandas as pd
+
+from .theming import Theme
+
+
+def prepare_timeseries(
+    df: pd.DataFrame,
+    metric: str,
+    resample: str,
+    aggregate: str,
+) -> pd.DataFrame:
+    if df.empty:
+        return df
+    ts = df.copy()
+    if not isinstance(ts.index, pd.DatetimeIndex):
+        ts.index = pd.to_datetime(ts.index, errors="coerce")
+    ts = ts.sort_index()
+    metric_series = pd.to_numeric(ts[metric], errors="coerce")
+    if resample:
+        metric_series = getattr(metric_series.resample(resample), aggregate)()
+    return metric_series.to_frame(name=metric)
+
+
+def build_metric_chart(
+    df: pd.DataFrame,
+    metric: str,
+    theme: Theme,
+    title: str | None = None,
+) -> alt.Chart:
+    chart = (
+        alt.Chart(df.reset_index())
+        .mark_area(line={"color": theme.primary}, color=theme.primary + "33")
+        .encode(
+            x=alt.X("index:T", title="Time"),
+            y=alt.Y(f"{metric}:Q", title=metric.replace("_", " ").title()),
+            tooltip=["index:T", alt.Tooltip(f"{metric}:Q", format=".2f")],
+        )
+    )
+    if title:
+        chart = chart.properties(title=title)
+    return chart.configure(
+        background=theme.background,
+        padding=10,
+    ).configure_title(color=theme.text).configure_axis(
+        labelColor=theme.muted_text,
+        titleColor=theme.text,
+        gridColor=theme.muted_text + "33",
+    )
+
+
+def describe_metric(df: pd.DataFrame, metric: str) -> Dict[str, float]:
+    if df.empty or metric not in df:
+        return {"min": float("nan"), "max": float("nan"), "mean": float("nan")}
+    series = pd.to_numeric(df[metric], errors="coerce")
+    return {
+        "min": float(series.min(skipna=True)),
+        "max": float(series.max(skipna=True)),
+        "mean": float(series.mean(skipna=True)),
+    }
+
+
+__all__ = ["prepare_timeseries", "build_metric_chart", "describe_metric"]

--- a/homesky/utils/db.py
+++ b/homesky/utils/db.py
@@ -1,0 +1,155 @@
+"""Database and storage helpers."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import pandas as pd
+from loguru import logger
+
+
+OBS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS observations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    mac TEXT NOT NULL,
+    obs_time_utc TEXT NOT NULL,
+    obs_time_local TEXT,
+    epoch INTEGER,
+    data JSON NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(mac, obs_time_utc)
+);
+"""
+
+
+@dataclass(slots=True)
+class DatabaseManager:
+    """Manage SQLite and Parquet persistence."""
+
+    sqlite_path: Path
+    parquet_path: Path
+
+    def __post_init__(self) -> None:
+        self.sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+        self.parquet_path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_schema(self.sqlite_path)
+
+    # -- SQLite helpers -------------------------------------------------
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self.sqlite_path)
+        connection.execute("PRAGMA journal_mode=WAL;")
+        connection.execute("PRAGMA synchronous=NORMAL;")
+        return connection
+
+    def insert_observations(self, rows: Iterable[Dict]) -> int:
+        """Insert observation rows, returning the count of new records."""
+
+        rows = list(rows)
+        if not rows:
+            return 0
+        inserted = 0
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            for row in rows:
+                payload_source = row.get("lastData") or row.get("raw") or row
+                mac = (
+                    row.get("mac")
+                    or row.get("macAddress")
+                    or payload_source.get("mac")
+                    or "unknown"
+                )
+                obs_time_utc = (
+                    row.get("obs_time_utc")
+                    or payload_source.get("obs_time_utc")
+                    or payload_source.get("dateutc")
+                )
+                obs_time_local = (
+                    row.get("obs_time_local")
+                    or payload_source.get("obs_time_local")
+                    or payload_source.get("date")
+                )
+                epoch = row.get("epoch") or payload_source.get("epoch")
+                payload = json.dumps(payload_source)
+                try:
+                    cursor.execute(
+                        """
+                        INSERT OR IGNORE INTO observations(mac, obs_time_utc, obs_time_local, epoch, data)
+                        VALUES(?,?,?,?,?)
+                        """,
+                        (mac, str(obs_time_utc), str(obs_time_local), epoch, payload),
+                    )
+                    inserted += cursor.rowcount
+                except sqlite3.DatabaseError as exc:  # pragma: no cover
+                    logger.exception("Failed to insert row: %s", exc)
+            conn.commit()
+        logger.debug("Inserted %d new rows into SQLite", inserted)
+        return inserted
+
+    def fetch_last_timestamp(self, mac: Optional[str] = None) -> Optional[str]:
+        query = "SELECT obs_time_utc FROM observations"
+        params: tuple = ()
+        if mac:
+            query += " WHERE mac = ?"
+            params = (mac,)
+        query += " ORDER BY obs_time_utc DESC LIMIT 1"
+        with self._connect() as conn:
+            row = conn.execute(query, params).fetchone()
+        return row[0] if row else None
+
+    def read_dataframe(
+        self, mac: Optional[str] = None, limit: Optional[int] = None
+    ) -> pd.DataFrame:
+        query = "SELECT mac, obs_time_utc, obs_time_local, epoch, data FROM observations"
+        params: tuple = ()
+        if mac:
+            query += " WHERE mac = ?"
+            params = (mac,)
+        query += " ORDER BY obs_time_utc"
+        if limit:
+            query += " LIMIT ?"
+            params = params + (limit,)
+        with self._connect() as conn:
+            df = pd.read_sql_query(query, conn, params=params)
+        if df.empty:
+            return df
+        expanded = pd.json_normalize(df["data"].apply(json.loads))
+        expanded.index = pd.to_datetime(df["obs_time_utc"], errors="coerce", utc=True)
+        expanded.insert(0, "mac", df["mac"].values)
+        expanded.insert(1, "obs_time_utc", pd.to_datetime(df["obs_time_utc"], errors="coerce", utc=True))
+        expanded.insert(2, "obs_time_local", pd.to_datetime(df["obs_time_local"], errors="coerce"))
+        expanded.insert(3, "epoch", df["epoch"].values)
+        return expanded
+
+    # -- Parquet helpers ------------------------------------------------
+    def append_parquet(self, df: pd.DataFrame) -> None:
+        if df.empty:
+            return
+        df_to_write = df.copy()
+        df_to_write.reset_index(drop=True, inplace=True)
+        write_kwargs = {
+            "engine": "pyarrow",
+            "compression": "snappy",
+            "index": False,
+        }
+        if self.parquet_path.exists():
+            existing = pd.read_parquet(self.parquet_path)
+            combined = pd.concat([existing, df_to_write], ignore_index=True)
+            combined.to_parquet(self.parquet_path, **write_kwargs)
+        else:
+            df_to_write.to_parquet(self.parquet_path, **write_kwargs)
+        logger.debug("Appended %d rows to Parquet lake", len(df_to_write))
+
+
+def ensure_schema(sqlite_path: Path | str) -> None:
+    path = Path(sqlite_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as conn:
+        conn.execute(OBS_TABLE_SQL)
+        conn.commit()
+
+
+__all__ = ["DatabaseManager", "ensure_schema"]

--- a/homesky/utils/derived.py
+++ b/homesky/utils/derived.py
@@ -1,0 +1,107 @@
+"""Derived metric calculations."""
+
+from __future__ import annotations
+
+from typing import Callable, Dict, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+DerivedFunc = Callable[[pd.DataFrame, Dict], pd.Series]
+
+_DERIVED_REGISTRY: Dict[str, Tuple[DerivedFunc, Optional[str]]] = {}
+
+
+def register_derived_metric(name: str, func: DerivedFunc, flag: Optional[str] = None) -> None:
+    _DERIVED_REGISTRY[name] = (func, flag)
+
+
+def compute_all_derived(df: pd.DataFrame, config: Dict) -> pd.DataFrame:
+    if df.empty:
+        return df
+    results = df.copy()
+    derived_cfg = config.get("derived", {})
+    for name, (func, flag) in _DERIVED_REGISTRY.items():
+        if flag and not derived_cfg.get(flag, True):
+            continue
+        try:
+            results[name] = func(df, config)
+        except Exception as exc:  # pragma: no cover
+            results[name] = np.nan
+            print(f"Failed to compute derived metric {name}: {exc}")
+    return results
+
+
+# -- Derived metric implementations ------------------------------------
+
+
+def _get_series(df: pd.DataFrame, *names: str) -> pd.Series:
+    for name in names:
+        if name in df:
+            return pd.to_numeric(df[name], errors="coerce")
+    return pd.Series(dtype="float64")
+
+
+def _hdd(df: pd.DataFrame, config: Dict) -> pd.Series:
+    base = config.get("derived", {}).get("hdd_base_f", 65)
+    temps_f = _get_series(df, "tempf", "temp_f", "temperature")
+    if temps_f.empty and "tempc" in df:
+        temps_f = _get_series(df, "tempc") * 9 / 5 + 32
+    return np.clip(base - temps_f, a_min=0, a_max=None)
+
+
+def _cdd(df: pd.DataFrame, config: Dict) -> pd.Series:
+    base = config.get("derived", {}).get("cdd_base_f", 65)
+    temps_f = _get_series(df, "tempf", "temp_f", "temperature")
+    if temps_f.empty and "tempc" in df:
+        temps_f = _get_series(df, "tempc") * 9 / 5 + 32
+    return np.clip(temps_f - base, a_min=0, a_max=None)
+
+
+def _wetbulb(df: pd.DataFrame, config: Dict) -> pd.Series:
+    temp_f = _get_series(df, "tempf", "temp_f")
+    if temp_f.empty and "tempc" in df:
+        temp_f = _get_series(df, "tempc") * 9 / 5 + 32
+    humidity = _get_series(df, "humidity", "humidity_percent")
+    temp_c = (temp_f - 32) * 5 / 9
+    humidity = humidity.clip(lower=0, upper=100)
+    wetbulb_c = (
+        (0.151977 * (humidity + 8.313659) ** 0.5)
+        + np.arctan(temp_c + humidity)
+        - np.arctan(humidity - 1.676331)
+        + 0.00391838 * humidity ** 1.5 * np.arctan(0.023101 * humidity)
+        - 4.686035
+    )
+    wetbulb_f = wetbulb_c * 9 / 5 + 32
+    return wetbulb_f
+
+
+def _vpd(df: pd.DataFrame, config: Dict) -> pd.Series:
+    temp_f = _get_series(df, "tempf", "temp_f")
+    if temp_f.empty and "tempc" in df:
+        temp_f = _get_series(df, "tempc") * 9 / 5 + 32
+    humidity = _get_series(df, "humidity", "humidity_percent")
+    temp_c = (temp_f - 32) * 5 / 9
+    es = 0.6108 * np.exp((17.27 * temp_c) / (temp_c + 237.3))
+    ea = humidity / 100 * es
+    vpd_kpa = es - ea
+    return vpd_kpa
+
+
+def _wind_run(df: pd.DataFrame, config: Dict) -> pd.Series:
+    wind_mph = _get_series(df, "windspeedmph", "wind_speed_mph")
+    gust_mph = _get_series(df, "windgustmph", "wind_gust_mph")
+    avg = pd.concat([wind_mph, gust_mph], axis=1).mean(axis=1, skipna=True)
+    return avg / 60  # assuming 1-minute cadence → miles per minute
+
+
+register_derived_metric("heating_degree_hours", _hdd)
+register_derived_metric("cooling_degree_hours", _cdd)
+register_derived_metric("wetbulb_temp_f", _wetbulb, flag="enable_wetbulb")
+register_derived_metric(
+    "vapor_pressure_deficit_kpa", _vpd, flag="enable_vpd"
+)
+register_derived_metric("wind_run_miles", _wind_run, flag="enable_wind_run")
+
+
+__all__ = ["compute_all_derived", "register_derived_metric"]

--- a/homesky/utils/theming.py
+++ b/homesky/utils/theming.py
@@ -1,0 +1,54 @@
+"""Dark-Sky-inspired theming helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass(slots=True)
+class Theme:
+    background: str
+    surface: str
+    primary: str
+    accent: str
+    text: str
+    muted_text: str
+
+
+DARK_THEME = Theme(
+    background="#0B101B",
+    surface="#141B2A",
+    primary="#4C6FFF",
+    accent="#F7B267",
+    text="#F5F7FF",
+    muted_text="#8792B0",
+)
+
+LIGHT_THEME = Theme(
+    background="#F6F7FB",
+    surface="#FFFFFF",
+    primary="#3753E0",
+    accent="#FF9F1C",
+    text="#1B1F30",
+    muted_text="#536080",
+)
+
+
+def get_theme(choice: str | None) -> Theme:
+    if choice == "light":
+        return LIGHT_THEME
+    if choice == "dark":
+        return DARK_THEME
+    return DARK_THEME
+
+
+def load_typography() -> Dict[str, str]:
+    return {
+        "font_family": "Inter, 'Segoe UI', sans-serif",
+        "title_size": "1.8rem",
+        "label_size": "0.9rem",
+    }
+
+
+__all__ = ["Theme", "get_theme", "load_typography"]

--- a/homesky/visualize_streamlit.py
+++ b/homesky/visualize_streamlit.py
@@ -1,0 +1,143 @@
+"""Streamlit dashboard for HomeSky."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+from pandas.api import types as ptypes
+import streamlit as st
+
+from utils.charts import build_metric_chart, describe_metric, prepare_timeseries
+from utils.db import DatabaseManager
+from utils.derived import compute_all_derived
+from utils.theming import get_theme, load_typography
+
+try:
+    import tomllib
+except ImportError:  # pragma: no cover
+    import tomli as tomllib  # type: ignore
+
+CONFIG_PATH = Path("config.toml")
+
+
+@st.cache_data(ttl=60)
+def load_config(path: Path = CONFIG_PATH) -> Dict:
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+@st.cache_data(ttl=60)
+def load_data(sqlite_path: str, parquet_path: str) -> pd.DataFrame:
+    db = DatabaseManager(Path(sqlite_path), Path(parquet_path))
+    df = db.read_dataframe()
+    return df
+
+
+def main() -> None:
+    st.set_page_config(page_title="HomeSky", layout="wide")
+    try:
+        config = load_config()
+    except FileNotFoundError:
+        st.error("Missing config.toml. Copy config.example.toml and update your credentials.")
+        st.stop()
+
+    theme_choice = config.get("visualization", {}).get("theme", "dark")
+    theme = get_theme(theme_choice)
+    typography = load_typography()
+
+    storage_cfg = config.get("storage", {})
+    df = load_data(storage_cfg.get("sqlite_path", "./data/homesky.sqlite"), storage_cfg.get("parquet_path", "./data/homesky.parquet"))
+
+    if df.empty:
+        st.info("No observations stored yet. Run ingest.py to begin capturing data.")
+        st.stop()
+
+    df = compute_all_derived(df, config)
+
+    st.sidebar.header("Controls")
+    numeric_columns = [col for col in df.columns if ptypes.is_numeric_dtype(df[col])]
+    if not numeric_columns:
+        st.error("No numeric columns available to plot.")
+        st.stop()
+    metrics = sorted(numeric_columns)
+    default_metric = config.get("visualization", {}).get("default_metric", metrics[0])
+    metric_index = metrics.index(default_metric) if default_metric in metrics else 0
+    metric = st.sidebar.selectbox("Metric", metrics, index=metric_index)
+
+    resample_options = ["", "15min", "H", "D", "W"]
+    default_resample = config.get("visualization", {}).get("default_resample", "H")
+    resample_index = resample_options.index(default_resample) if default_resample in resample_options else 0
+    resample = st.sidebar.selectbox(
+        "Resample",
+        options=resample_options,
+        index=resample_index,
+        format_func=lambda x: "Raw" if x == "" else x,
+    )
+
+    aggregate_options = ["mean", "min", "max", "median"]
+    default_aggregate = config.get("visualization", {}).get("default_aggregate", "mean")
+    aggregate_index = (
+        aggregate_options.index(default_aggregate)
+        if default_aggregate in aggregate_options
+        else 0
+    )
+    aggregate = st.sidebar.selectbox(
+        "Aggregate",
+        options=aggregate_options,
+        index=aggregate_index,
+    )
+    date_range = st.sidebar.date_input(
+        "Date range",
+        value=(df.index.min().date(), df.index.max().date()),
+    )
+
+    if isinstance(date_range, tuple) and len(date_range) == 2:
+        start, end = date_range
+        mask = (df.index.date >= start) & (df.index.date <= end)
+        df = df.loc[mask]
+
+    st.markdown(
+        f"""
+        <style>
+        body {{ background-color: {theme.background}; color: {theme.text}; }}
+        .stApp {{ font-family: {typography['font_family']}; }}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    prepared = prepare_timeseries(df, metric, resample, aggregate)
+
+    if prepared.empty:
+        st.warning("No data available for the selected range/metric.")
+        st.stop()
+
+    st.title("HomeSky Dashboard")
+    st.altair_chart(build_metric_chart(prepared, metric, theme, title=metric.title()), use_container_width=True)
+
+    stats = describe_metric(prepared, metric)
+    cols = st.columns(3)
+    cols[0].metric("Min", f"{stats['min']:.2f}")
+    cols[1].metric("Mean", f"{stats['mean']:.2f}")
+    cols[2].metric("Max", f"{stats['max']:.2f}")
+
+    st.subheader("Data Explorer")
+    st.dataframe(df.tail(500))
+
+    csv = df.to_csv().encode("utf-8")
+    st.download_button("Download CSV", csv, file_name="homesky.csv", mime="text/csv")
+    parquet_buffer = BytesIO()
+    df.to_parquet(parquet_buffer, engine="pyarrow")
+    st.download_button(
+        "Download Parquet",
+        parquet_buffer.getvalue(),
+        file_name="homesky.parquet",
+        mime="application/octet-stream",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+PySimpleGUI>=5.0
+pandas>=2.2
+numpy>=1.26
+requests>=2.32
+pyyaml>=6.0
+python-dateutil>=2.9
+streamlit>=1.36
+loguru>=0.7

--- a/run_gui.ps1
+++ b/run_gui.ps1
@@ -1,0 +1,4 @@
+# run_gui.ps1 — ensure venv+deps, ensure config, then launch GUI
+.\tools\ensure_venv_and_deps.ps1
+.\tools\ensure_config.ps1
+python .\homesky\gui.py

--- a/tools/ensure_config.ps1
+++ b/tools/ensure_config.ps1
@@ -1,0 +1,27 @@
+param(
+  [string]$Config = ".\homesky\config.toml",
+  [string]$Example = ".\homesky\config.example.toml"
+)
+
+if (-not (Test-Path $Config)) {
+  if (Test-Path $Example) {
+    Write-Host "[config] Creating config.toml from example..." -ForegroundColor Cyan
+    Copy-Item $Example $Config
+  } else {
+    Write-Host "[config] No example found; creating a minimal stub..." -ForegroundColor Yellow
+    @"
+[ambient]
+api_key = ""
+application_key = ""
+mac = ""
+
+[storage]
+root_dir = "./data"
+sqlite_path = "./data/homesky.sqlite"
+parquet_path = "./data/homesky.parquet"
+"@ | Out-File -Encoding utf8 $Config
+  }
+  Write-Host "[config] Edit $Config to add credentials." -ForegroundColor Yellow
+} else {
+  Write-Host "[config] config.toml present." -ForegroundColor Green
+}

--- a/tools/ensure_venv_and_deps.ps1
+++ b/tools/ensure_venv_and_deps.ps1
@@ -1,0 +1,36 @@
+param(
+  [string]$ReqPath = ".\requirements.txt",
+  [string]$ExtraIndex = "https://PySimpleGUI.net/install"
+)
+
+# Ensure venv exists
+if (-not (Test-Path .\.venv\Scripts\Activate.ps1)) {
+  Write-Host "[venv] creating..." -ForegroundColor Cyan
+  python -m venv .venv
+}
+
+# Activate venv
+. .\.venv\Scripts\Activate.ps1
+
+# Upgrade pip quietly
+python -m pip install --upgrade pip | Out-Null
+
+# Compute current requirements hash
+if (-not (Test-Path $ReqPath)) {
+  Write-Error "requirements.txt not found at $ReqPath"
+  exit 1
+}
+$hashFile = ".\.venv\.req.hash"
+$current = (Get-FileHash $ReqPath -Algorithm SHA256).Hash
+$prior = ""
+if (Test-Path $hashFile) { $prior = Get-Content $hashFile -Raw }
+
+if ($current -ne $prior) {
+  Write-Host "[deps] requirements changed or first run -> installing..." -ForegroundColor Yellow
+  pip install -r $ReqPath --extra-index-url $ExtraIndex
+  Set-Content -Path $hashFile -Value $current -Encoding UTF8
+} else {
+  Write-Host "[deps] requirements unchanged -> skipping installs." -ForegroundColor Green
+}
+
+# Return the venv activated in the caller shell


### PR DESCRIPTION
## Summary
- add reusable PowerShell scripts to cache virtual environment installs and scaffold config.toml automatically
- provide run and build convenience entry points that reuse the helpers and emit the build sentinel
- update the GUI and ingest loader to create starter configs and document the streamlined workflow in the README

## Testing
- python -m compileall homesky

------
https://chatgpt.com/codex/tasks/task_e_68e1a0593e78832e9edb1c6846dd3824