### PR TITLE
Support external HomeSky config location

### DIFF
--- a/homesky/gui.py
+++ b/homesky/gui.py
@@ -10,11 +10,16 @@ from pathlib import Path
 import PySimpleGUI as sg
 
 import ingest
+from utils.config import (
+    bootstrap_target_path,
+    candidate_config_paths,
+    ensure_parent_directory,
+)
 from utils.db import DatabaseManager
 
 PACKAGE_DIR = Path(__file__).resolve().parent
 CONFIG_EXAMPLE = PACKAGE_DIR / "config.example.toml"
-CONFIG_TARGETS = [Path("config.toml"), PACKAGE_DIR / "config.toml"]
+CONFIG_TARGETS = candidate_config_paths()
 STREAMLIT_ENTRY = PACKAGE_DIR / "visualize_streamlit.py"
 
 
@@ -22,7 +27,8 @@ def bootstrap_config_file() -> Path:
     for candidate in CONFIG_TARGETS:
         if candidate.exists():
             return candidate
-    target = CONFIG_TARGETS[-1]
+    target = bootstrap_target_path()
+    ensure_parent_directory(target)
     if CONFIG_EXAMPLE.exists():
         target.write_text(CONFIG_EXAMPLE.read_text(), encoding="utf-8")
     else:

--- a/homesky/ingest.py
+++ b/homesky/ingest.py
@@ -12,6 +12,7 @@ import pandas as pd
 from loguru import logger
 
 from utils.ambient import AmbientClient
+from utils.config import candidate_config_paths
 from utils.db import DatabaseManager
 from utils.derived import compute_all_derived
 
@@ -21,13 +22,13 @@ except ImportError:  # pragma: no cover
     import tomli as tomllib  # type: ignore
 
 
-CONFIG_PATHS = [Path("config.toml"), Path("homesky/config.toml")]
-
-
 def load_config(path: Path | None = None) -> Dict:
-    candidates = [path] if path else CONFIG_PATHS
+    if path:
+        candidates = [path]
+    else:
+        candidates = candidate_config_paths()
     for candidate in candidates:
-        if candidate and candidate.exists():
+        if candidate.exists():
             with candidate.open("rb") as fh:
                 return tomllib.load(fh)
     raise FileNotFoundError(

--- a/homesky/utils/config.py
+++ b/homesky/utils/config.py
@@ -1,0 +1,89 @@
+"""Shared helpers for locating HomeSky configuration files."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+ENVIRONMENT_VARIABLE = "HOMESKY_CONFIG"
+APP_DIR_NAME = "HomeSky"
+CONFIG_FILENAME = "config.toml"
+
+
+def _unique_paths(paths: Iterable[Path]) -> List[Path]:
+    """Return the given paths with duplicates removed while preserving order."""
+
+    seen: set[Path] = set()
+    ordered: List[Path] = []
+    for path in paths:
+        resolved = path.expanduser()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        ordered.append(resolved)
+    return ordered
+
+
+def environment_config_path() -> Path | None:
+    """Return the config path specified via HOMESKY_CONFIG, if provided."""
+
+    configured = os.environ.get(ENVIRONMENT_VARIABLE)
+    if not configured:
+        return None
+    return Path(configured).expanduser()
+
+
+def external_config_directory() -> Path:
+    """Return the OS-appropriate directory for storing persistent config."""
+
+    if sys.platform.startswith("win"):
+        appdata = os.environ.get("APPDATA")
+        if appdata:
+            return Path(appdata) / APP_DIR_NAME
+    elif sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / APP_DIR_NAME
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg) / APP_DIR_NAME
+    return Path.home() / ".config" / APP_DIR_NAME
+
+
+def external_config_path() -> Path:
+    """Return the preferred external config path."""
+
+    return external_config_directory() / CONFIG_FILENAME
+
+
+def repository_config_paths() -> List[Path]:
+    """Return config paths that live within the repository tree."""
+
+    return [Path(CONFIG_FILENAME), Path("homesky") / CONFIG_FILENAME]
+
+
+def candidate_config_paths() -> List[Path]:
+    """Return config locations in priority order for loading."""
+
+    env_path = environment_config_path()
+    paths: List[Path] = []
+    if env_path:
+        paths.append(env_path)
+    paths.append(external_config_path())
+    paths.extend(repository_config_paths())
+    return _unique_paths(paths)
+
+
+def bootstrap_target_path() -> Path:
+    """Return the path where a new config should be created when missing."""
+
+    env_path = environment_config_path()
+    if env_path:
+        return env_path
+    return external_config_path()
+
+
+def ensure_parent_directory(path: Path) -> None:
+    """Create the parent directory for *path* if it does not already exist."""
+
+    path.expanduser().parent.mkdir(parents=True, exist_ok=True)

--- a/tools/ensure_config.ps1
+++ b/tools/ensure_config.ps1
@@ -1,7 +1,24 @@
 param(
-  [string]$Config = ".\homesky\config.toml",
+  [string]$Config,
   [string]$Example = ".\homesky\config.example.toml"
 )
+
+if (-not $PSBoundParameters.ContainsKey('Config') -or [string]::IsNullOrWhiteSpace($Config)) {
+  if ($env:HOMESKY_CONFIG) {
+    $Config = $env:HOMESKY_CONFIG
+  } elseif ($env:APPDATA) {
+    $Config = Join-Path $env:APPDATA "HomeSky\config.toml"
+  } elseif ($env:XDG_CONFIG_HOME) {
+    $Config = Join-Path $env:XDG_CONFIG_HOME "HomeSky/config.toml"
+  } else {
+    $Config = "$HOME/.config/HomeSky/config.toml"
+  }
+}
+
+$destinationDir = Split-Path -Parent $Config
+if (-not (Test-Path $destinationDir)) {
+  New-Item -ItemType Directory -Path $destinationDir -Force | Out-Null
+}
 
 if (-not (Test-Path $Config)) {
   if (Test-Path $Example) {


### PR DESCRIPTION
## Summary
- add shared helpers for discovering HomeSky configuration files and defaulting to an external location
- update the ingest service and GUI launcher to respect the new discovery order and create configs outside the repo by default
- enhance the ensure_config PowerShell script to seed the persistent config directory automatically

## Testing
- python -m compileall homesky

------
https://chatgpt.com/codex/tasks/task_e_68e1c56b1a28832eab9cf5c322a7935a