### PR TITLE
Improve config handling and README guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,113 +1,29 @@
 # HomeSky
 single-user Windows desktop app for Ambient Weather station with long-term capture, Dark-Sky-style visuals, and rich exports (web-ready later)
 
-### Fix-Now (if paths drift)
-
-> These commands reset you to a clean repo root, avoid double `HomeSky\HomeSky` nesting, and recreate helper scripts if they were deleted locally.
-
-```pwsh
-# 0) Always start from the Desktop using PowerShell syntax
-Set-Location -Path "$env:USERPROFILE\Desktop"
-
-# 1) If you accidentally nested into HomeSky\HomeSky, move back up once
-if (Test-Path ".\HomeSky\HomeSky\.git") { Set-Location ".\HomeSky" }
-
-# 2) Fresh clone or refresh without double-cd
-if (Test-Path ".\HomeSky\.git") {
-  Set-Location ".\HomeSky"
-  git fetch origin
-  git reset --hard origin/main
-  git clean -xfd
-} else {
-  git clone https://github.com/Balooog/HomeSky.git
-  Set-Location ".\HomeSky"
-}
-
-# 3) Recreate helper scripts if they are missing
-if (-not (Test-Path ".\tools")) { New-Item -ItemType Directory -Path ".\tools" | Out-Null }
-
-@'
-param(
-  [string]$ReqPath = ".\requirements.txt",
-  [string]$ExtraIndex = "https://PySimpleGUI.net/install"
-)
-
-if (-not (Test-Path .\.venv\Scripts\Activate.ps1)) {
-  Write-Host "[venv] creating..." -ForegroundColor Cyan
-  python -m venv .venv
-}
-
-. .\.venv\Scripts\Activate.ps1
-python -m pip install --upgrade pip | Out-Null
-
-if (-not (Test-Path $ReqPath)) {
-  Write-Error "requirements.txt not found at $ReqPath"
-  exit 1
-}
-
-$hashFile = ".\.venv\.req.hash"
-$current = (Get-FileHash $ReqPath -Algorithm SHA256).Hash
-$prior = (Test-Path $hashFile) ? (Get-Content $hashFile -Raw) : ""
-
-if ($current -ne $prior) {
-  Write-Host "[deps] installing/refreshing..." -ForegroundColor Yellow
-  pip install -r $ReqPath --extra-index-url $ExtraIndex
-  Set-Content -Path $hashFile -Value $current -Encoding UTF8
-} else {
-  Write-Host "[deps] requirements unchanged -> skipping installs." -ForegroundColor Green
-}
-"@ | Out-File -Encoding utf8 ".\tools\ensure_venv_and_deps.ps1"
-
-@'
-param(
-  [string]$Config = ".\homesky\config.toml",
-  [string]$Example = ".\homesky\config.example.toml"
-)
-
-if (-not (Test-Path $Config)) {
-  if (Test-Path $Example) {
-    Write-Host "[config] creating from example..." -ForegroundColor Cyan
-    Copy-Item $Example $Config
-  } else {
-    Write-Host "[config] creating minimal stub..." -ForegroundColor Yellow
-@"
-[ambient]
-api_key = ""
-application_key = ""
-mac = ""
-
-[storage]
-root_dir = "./data"
-sqlite_path = "./data/homesky.sqlite"
-parquet_path = "./data/homesky.parquet"
-"@ | Out-File -Encoding utf8 $Config
-  }
-  Write-Host "[config] Edit $Config to add credentials." -ForegroundColor Yellow
-} else {
-  Write-Host "[config] present." -ForegroundColor Green
-}
-"@ | Out-File -Encoding utf8 ".\tools\ensure_config.ps1"
-```
-
 ### Daily dev run (fast feedback)
 
 ```pwsh
-Set-Location -Path "$env:USERPROFILE\Desktop"
+Set-Location "$env:USERPROFILE\Desktop"
 
-if (Test-Path ".\HomeSky\.git") {
-  Set-Location ".\HomeSky"
-  git fetch origin
-  git reset --hard origin/main
-  git clean -xfd
-} else {
+if (-not (Test-Path ".\HomeSky")) {
   git clone https://github.com/Balooog/HomeSky.git
-  Set-Location ".\HomeSky"
 }
+
+Set-Location ".\HomeSky"
+
+git fetch origin
+git reset --hard origin/main
+# (Keep .venv for faster runs; avoid: git clean -xfd)
 
 .\tools\ensure_venv_and_deps.ps1
 .\tools\ensure_config.ps1
+
 python .\homesky\gui.py
+# Test Build Complete
 ```
+
+> Tip: `git clean -xfd` deletes `.venv/` and `homesky/config.toml`. Skip it unless you intentionally want a factory reset.
 
 ### Configure & relaunch (first run)
 
@@ -116,6 +32,28 @@ python .\homesky\gui.py
 ```pwsh
 notepad .\homesky\config.toml
 python .\homesky\gui.py
+```
+
+### Known-good config template
+
+Paste this into `homesky\config.toml` (UTF-8 without BOM) and fill in your credentials:
+
+```toml
+[ambient]
+api_key = "<YOUR_API_KEY>"
+application_key = "<YOUR_APP_KEY>"
+mac = "C4:5B:BE:6E:93:3D"
+
+[storage]
+root_dir = "./data"
+sqlite_path = "./data/homesky.sqlite"
+parquet_path = "./data/homesky.parquet"
+```
+
+If you run into missing Python packages later, rerun:
+
+```pwsh
+pip install -r requirements.txt --extra-index-url https://PySimpleGUI.net/install
 ```
 
 ### Configure

--- a/homesky/ingest.py
+++ b/homesky/ingest.py
@@ -29,8 +29,20 @@ def load_config(path: Path | None = None) -> Dict:
         candidates = candidate_config_paths()
     for candidate in candidates:
         if candidate.exists():
-            with candidate.open("rb") as fh:
-                return tomllib.load(fh)
+            try:
+                with candidate.open("rb") as fh:
+                    config = tomllib.load(fh)
+            except tomllib.TOMLDecodeError as exc:
+                logger.error("Failed to parse config at {}: {}", candidate, exc)
+                logger.info(
+                    "Open the file in a text editor, ensure it starts with [ambient] on the first line, and save it as UTF-8 without a BOM."
+                )
+                logger.info(
+                    "To recreate a clean template, rename the broken file then run tools/ensure_config.ps1 or copy homesky/config.example.toml manually."
+                )
+                raise
+            print("[config] Loaded successfully")
+            return config
     raise FileNotFoundError(
         "config.toml not found. Run tools/ensure_config.ps1 or copy homesky/config.example.toml to homesky/config.toml and populate your credentials."
     )

--- a/tools/ensure_venv_and_deps.ps1
+++ b/tools/ensure_venv_and_deps.ps1
@@ -31,6 +31,7 @@ if ($current -ne $prior) {
   Set-Content -Path $hashFile -Value $current -Encoding UTF8
 } else {
   Write-Host "[deps] requirements unchanged -> skipping installs." -ForegroundColor Green
+  Write-Host "[deps] If you hit missing module errors, run: pip install -r requirements.txt --extra-index-url $ExtraIndex" -ForegroundColor DarkYellow
 }
 
 # Return the venv activated in the caller shell


### PR DESCRIPTION
## Summary
- streamline the README refresh flow to keep the existing virtual environment, add a reference config snippet, and note the manual dependency reinstall command
- make `ingest.load_config` print a success message and log actionable guidance when TOML parsing fails
- remind developers running `ensure_venv_and_deps.ps1` how to manually refresh dependencies if modules are missing

## Testing
- python -m compileall homesky

------
https://chatgpt.com/codex/tasks/task_e_68e1cb1f6cc4832e8c92bb108e05fbdf