### PR TITLE
Improve config parsing resilience and preservation

### DIFF
--- a/tools/ensure_config.ps1
+++ b/tools/ensure_config.ps1
@@ -1,17 +1,36 @@
 param(
   [string]$Config,
-  [string]$Example = ".\homesky\config.example.toml"
+  [string]$Example = ".\homesky\config.example.toml",
+  [bool]$PreserveConfig = $true
 )
 
-if (-not $PSBoundParameters.ContainsKey('Config') -or [string]::IsNullOrWhiteSpace($Config)) {
+function Get-PreferredConfigPath {
   if ($env:HOMESKY_CONFIG) {
-    $Config = $env:HOMESKY_CONFIG
-  } elseif ($env:APPDATA) {
-    $Config = Join-Path $env:APPDATA "HomeSky\config.toml"
-  } elseif ($env:XDG_CONFIG_HOME) {
-    $Config = Join-Path $env:XDG_CONFIG_HOME "HomeSky/config.toml"
-  } else {
-    $Config = "$HOME/.config/HomeSky/config.toml"
+    return $env:HOMESKY_CONFIG
+  }
+  if ($env:APPDATA) {
+    return (Join-Path $env:APPDATA "HomeSky\config.toml")
+  }
+  if ($env:XDG_CONFIG_HOME) {
+    return (Join-Path $env:XDG_CONFIG_HOME "HomeSky/config.toml")
+  }
+  return "$HOME/.config/HomeSky/config.toml"
+}
+
+$preferredPath = Get-PreferredConfigPath
+
+if (-not $PSBoundParameters.ContainsKey('Config') -or [string]::IsNullOrWhiteSpace($Config)) {
+  $Config = $preferredPath
+} elseif ($PreserveConfig) {
+  try {
+    $resolvedConfig = [System.IO.Path]::GetFullPath((Join-Path (Get-Location) $Config))
+  } catch {
+    $resolvedConfig = $Config
+  }
+  $repoRoot = [System.IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+  if ($resolvedConfig.StartsWith($repoRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+    Write-Host "[config] preserve_config active; redirecting to persistent path $preferredPath" -ForegroundColor Yellow
+    $Config = $preferredPath
   }
 }
 
@@ -26,7 +45,7 @@ if (-not (Test-Path $Config)) {
     Copy-Item $Example $Config
   } else {
     Write-Host "[config] No example found; creating a minimal stub..." -ForegroundColor Yellow
-    @"
+    $stub = @"
 [ambient]
 api_key = ""
 application_key = ""
@@ -36,7 +55,9 @@ mac = ""
 root_dir = "./data"
 sqlite_path = "./data/homesky.sqlite"
 parquet_path = "./data/homesky.parquet"
-"@ | Out-File -Encoding utf8 $Config
+"@
+    $utf8 = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Config, $stub, $utf8)
   }
   Write-Host "[config] Edit $Config to add credentials." -ForegroundColor Yellow
 } else {


### PR DESCRIPTION
## Summary
- add BOM-safe normalization, backup/restore, and metadata reporting to `ingest.load_config`
- surface configuration repair feedback in the GUI before continuing and log normalization notices
- update `tools/ensure_config.ps1` to default to persistent locations, honor a preserve flag, and write UTF-8 without a BOM

## Testing
- python -m compileall homesky

------
https://chatgpt.com/codex/tasks/task_e_68e1d31ddfb4832e920a18846e97de5c