### PR TITLE
Fix Streamlit config detection and add historical backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ python .\homesky\gui.py
   launch_streamlit = true
   dashboard_port = 8501
   ```
-- **Fetching more history** – The current build ingests incremental updates as they arrive. A dedicated backfill command
-  (to load large historical windows) is planned for a follow-up release, so there is no need to delete the existing
-  database to "force" older data.
+- **Fetching more history** – Click **Backfill (24h)** in the GUI to pull a full day of history on demand. The ingest
+  service also backfills automatically on the first run using the `[ingest].backfill_hours` setting in `config.toml`, so
+  there is no need to delete the existing database to "force" older data.
 
 ### Known-good config template
 
@@ -88,3 +88,5 @@ python -m PyInstaller --onefile --clean --name HomeSky --distpath dist homesky\g
 
 Write-Host "# Test Build Complete" -ForegroundColor Green
 ```
+
+# Test Build Complete

--- a/homesky/config.example.toml
+++ b/homesky/config.example.toml
@@ -30,6 +30,7 @@ log_path = "./data/logs/ingest.log"
 log_rotate_days = 14
 max_retries = 3
 retry_backoff_sec = 10
+backfill_hours = 24  # attempt to backfill this many hours on the first run
 
 [visualization]
 default_metric = "temp_f"
@@ -47,3 +48,4 @@ quiet_hours_local = "22:00-07:00"
 
 [ui]
 launch_streamlit = false  # enable when visualize_streamlit.py is available
+dashboard_port = 8501     # optional override for Streamlit port


### PR DESCRIPTION
## Summary
- switch the Streamlit dashboard to the shared ingest config loader and improve its error handling
- add historical backfill orchestration, first-run auto backfill, and a GUI shortcut for manual backfills
- extend the Ambient Weather utilities plus config and docs to cover the new backfill and dashboard options

## Testing
- python -m compileall homesky/utils/ambient.py homesky/ingest.py homesky/visualize_streamlit.py homesky/gui.py

------
https://chatgpt.com/codex/tasks/task_e_68e1de7c1240832eab218966ddb1f9bc