### PR TITLE
Implement rate-limited backfill and offline import

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,16 @@ python .\homesky\gui.py
   launch_streamlit = true
   dashboard_port = 8501
   ```
-- **Fetching more history** – Click **Backfill (24h)** in the GUI to pull a full day of history on demand. The ingest
-  service also backfills automatically on the first run using the `[ingest].backfill_hours` setting in `config.toml`, so
-  there is no need to delete the existing database to "force" older data.
+- **Fetching more history** – Click **Backfill (24h)** in the GUI to pull a full day of history on demand. Use
+  **Backfill (custom)** to enter wider ranges; progress is checkpointed to `data/state/backfill.json` so interrupted jobs
+  resume safely. The ingest service also backfills automatically on the first run using the `[ingest].backfill_hours`
+  setting in `config.toml`, so there is no need to delete the existing database to "force" older data.
+- **API limits respected** – Ambient Weather limits each user key to ~1 request/sec (and each application key to 3/sec).
+  HomeSky enforces these ceilings with a shared throttle, jitter, and exponential backoff (1s → 2s → 4s → 8s) so long
+  backfills finish without `429` storms.
+- **Offline imports** – Fill historical gaps without touching the API. Drop CSV/XLSX exports in the GUI via
+  **Import file(s)** (or run `python -m homesky.import_offline data/import/*.csv`) and HomeSky will normalize the columns,
+  dedupe by `(mac, epoch_ms)`, append to SQLite/Parquet, and write a JSON report to `data/logs/import_*.json`.
 
 ### Known-good config template
 

--- a/homesky/backfill.py
+++ b/homesky/backfill.py
@@ -1,0 +1,178 @@
+"""Historical Ambient Weather backfill utilities."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+import pandas as pd
+from loguru import logger
+
+from storage import StorageManager, StorageResult, canonicalize_records
+from utils.ambient import AmbientClient
+
+
+@dataclass(slots=True)
+class BackfillState:
+    start: pd.Timestamp
+    end: pd.Timestamp
+    cursor: pd.Timestamp
+    mac: str
+
+
+def _checkpoint_path(config: Dict) -> Path:
+    storage_cfg = config.get("storage", {})
+    root = Path(storage_cfg.get("root_dir", "./data"))
+    return root / "state" / "backfill.json"
+
+
+def _load_checkpoint(path: Path) -> Optional[BackfillState]:
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):  # pragma: no cover - defensive guard
+        logger.warning("Backfill checkpoint at %s is corrupt; ignoring", path)
+        return None
+    try:
+        start = pd.to_datetime(payload["start"], utc=True)
+        end = pd.to_datetime(payload["end"], utc=True)
+        cursor = pd.to_datetime(payload["cursor"], utc=True)
+        mac = str(payload["mac"])
+    except Exception as exc:  # pragma: no cover - defensive guard
+        logger.warning("Backfill checkpoint missing fields: %s", exc)
+        return None
+    return BackfillState(start=start, end=end, cursor=cursor, mac=mac)
+
+
+def _save_checkpoint(path: Path, state: BackfillState) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "start": state.start.isoformat(),
+        "end": state.end.isoformat(),
+        "cursor": state.cursor.isoformat(),
+        "mac": state.mac,
+    }
+    path.write_text(json.dumps(payload, indent=2))
+
+
+def _clear_checkpoint(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return
+    except OSError as exc:  # pragma: no cover - best-effort cleanup
+        logger.warning("Unable to remove backfill checkpoint: %s", exc)
+
+
+def _apply_filters(df: pd.DataFrame, config: Dict) -> pd.DataFrame:
+    if df.empty:
+        return df
+    ingest_cfg = config.get("ingest", {})
+    if not ingest_cfg.get("drop_implausible_values", True):
+        return df
+    mask = pd.Series(True, index=df.index)
+    if "tempf" in df:
+        mask &= df["tempf"].between(-80, 150)
+    if "windspeedmph" in df:
+        mask &= df["windspeedmph"].between(0, 200)
+    if "humidity" in df:
+        mask &= df["humidity"].between(0, 100)
+    return df.loc[mask]
+
+
+def backfill_range(
+    *,
+    config: Dict,
+    storage: StorageManager,
+    start_dt: datetime | pd.Timestamp,
+    end_dt: datetime | pd.Timestamp,
+    mac: str,
+    window_minutes: int = 24 * 60,
+    limit_per_call: int = 288,
+) -> StorageResult:
+    if limit_per_call <= 0:
+        raise ValueError("limit_per_call must be positive")
+    start_ts = pd.to_datetime(start_dt, utc=True)
+    end_ts = pd.to_datetime(end_dt, utc=True)
+    if start_ts >= end_ts:
+        return StorageResult(0, None, None)
+    checkpoint_file = _checkpoint_path(config)
+    checkpoint = _load_checkpoint(checkpoint_file)
+    if checkpoint and checkpoint.mac == mac:
+        start_ts = max(start_ts, checkpoint.start)
+        end_ts = min(end_ts, checkpoint.end)
+        cursor = checkpoint.cursor
+    else:
+        cursor = end_ts
+    client = AmbientClient(
+        api_key=config["ambient"]["api_key"],
+        application_key=config["ambient"]["application_key"],
+        mac=mac,
+    )
+    total_inserted = 0
+    overall_start: Optional[pd.Timestamp] = None
+    overall_end: Optional[pd.Timestamp] = None
+    window_delta = pd.Timedelta(minutes=max(window_minutes, 1))
+
+    while cursor > start_ts:
+        window_end = cursor
+        window_start = max(start_ts, cursor - window_delta)
+        logger.info(
+            "[Backfill] Requesting history for %s between %s and %s",
+            mac,
+            window_start,
+            window_end,
+        )
+        records = client.get_device_data(mac=mac, end_dt=window_end.to_pydatetime(), limit=limit_per_call)
+        if not records:
+            cursor = window_start
+            _save_checkpoint(
+                checkpoint_file,
+                BackfillState(start=start_ts, end=end_ts, cursor=cursor, mac=mac),
+            )
+            if window_start == start_ts:
+                break
+            continue
+        canonical = canonicalize_records(records, mac_hint=mac)
+        if canonical.empty:
+            cursor = window_start
+            continue
+        canonical = canonical.loc[(canonical.index >= window_start) & (canonical.index <= window_end)]
+        canonical = _apply_filters(canonical, config)
+        if canonical.empty:
+            cursor = window_start
+            continue
+        result = storage.upsert_canonical(canonical)
+        total_inserted += result.inserted
+        if result.start is not None:
+            overall_start = result.start if overall_start is None else min(overall_start, result.start)
+        if result.end is not None:
+            overall_end = result.end if overall_end is None else max(overall_end, result.end)
+        logger.info(
+            "[Backfill] Inserted %s rows covering %s – %s",
+            result.inserted,
+            result.start,
+            result.end,
+        )
+        oldest = canonical.index.min()
+        if oldest <= start_ts:
+            cursor = start_ts
+        else:
+            cursor = oldest - pd.Timedelta(seconds=1)
+        _save_checkpoint(
+            checkpoint_file,
+            BackfillState(start=start_ts, end=end_ts, cursor=cursor, mac=mac),
+        )
+
+    if cursor <= start_ts:
+        _clear_checkpoint(checkpoint_file)
+
+    return StorageResult(total_inserted, overall_start, overall_end)
+
+
+__all__ = ["backfill_range"]
+

--- a/homesky/import_offline.py
+++ b/homesky/import_offline.py
@@ -1,0 +1,218 @@
+"""Offline import utilities for Ambient Weather CSV/XLSX exports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+import pandas as pd
+from loguru import logger
+
+import ingest
+from storage import StorageManager, canonicalize_records
+
+SUPPORTED_EXTENSIONS = {".csv", ".xlsx", ".xls"}
+
+CANONICAL_RENAMES = {
+    "temperaturef": "tempf",
+    "temperature_f": "tempf",
+    "temp_f": "tempf",
+    "temperature": "tempf",
+    "humidity_percent": "humidity",
+    "relative_humidity": "humidity",
+    "wind_speed_mph": "windspeedmph",
+    "wind_speed": "windspeedmph",
+    "windgustmph": "windgustmph",
+    "wind_gust_mph": "windgustmph",
+    "wind_gust": "windgustmph",
+    "winddir": "winddir",
+    "wind_direction": "winddir",
+    "pressurein": "baromin",
+    "baromin": "baromin",
+    "barometer_in": "baromin",
+    "precipitationin": "rainin",
+    "precip_in": "rainin",
+    "rainfall_in": "rainin",
+    "rain": "rainin",
+    "dewpointf": "dewptf",
+    "dew_point_f": "dewptf",
+    "solar_radiation": "solarradiation",
+    "uv": "uv",
+}
+
+TIMESTAMP_COLUMNS = (
+    "dateutc",
+    "timestamp_utc",
+    "datetime_utc",
+    "time_utc",
+    "timestamp",
+    "datetime",
+)
+
+LOCAL_TIME_COLUMNS = ("date", "time", "timestamp_local", "datetime_local")
+
+
+def _read_table(path: Path) -> pd.DataFrame:
+    suffix = path.suffix.lower()
+    if suffix not in SUPPORTED_EXTENSIONS:
+        raise ValueError(f"Unsupported file type: {path}")
+    if suffix == ".csv":
+        return pd.read_csv(path)
+    return pd.read_excel(path, sheet_name=0)
+
+
+def _normalize_columns(df: pd.DataFrame) -> pd.DataFrame:
+    renamed = {}
+    for column in df.columns:
+        lower = str(column).strip().lower()
+        renamed[column] = CANONICAL_RENAMES.get(lower, lower)
+    normalized = df.rename(columns=renamed)
+    normalized.columns = [str(col).strip() for col in normalized.columns]
+    return normalized
+
+
+def _combine_date_time(df: pd.DataFrame) -> Optional[pd.Series]:
+    if "date" in df.columns and "time" in df.columns:
+        combined = df["date"].astype(str).str.strip() + " " + df["time"].astype(str).str.strip()
+        return pd.to_datetime(combined, utc=True, errors="coerce")
+    return None
+
+
+def _extract_timestamp_series(df: pd.DataFrame) -> pd.Series:
+    for column in TIMESTAMP_COLUMNS:
+        if column in df.columns:
+            series = pd.to_datetime(df[column], utc=True, errors="coerce")
+            if series.notna().any():
+                return series
+    combined = _combine_date_time(df)
+    if combined is not None and combined.notna().any():
+        return combined
+    raise ValueError("Could not determine timestamp column in offline import")
+
+
+def _extract_local_series(df: pd.DataFrame) -> Optional[pd.Series]:
+    for column in LOCAL_TIME_COLUMNS:
+        if column in df.columns:
+            series = pd.to_datetime(df[column], errors="coerce")
+            if series.notna().any():
+                return series
+    return None
+
+
+def _frame_to_records(
+    df: pd.DataFrame,
+    *,
+    mac: Optional[str],
+) -> List[dict]:
+    normalized = _normalize_columns(df)
+    timestamps = _extract_timestamp_series(normalized)
+    local_series = _extract_local_series(normalized)
+    records: List[dict] = []
+    for idx, row in normalized.iterrows():
+        timestamp = timestamps.iloc[idx] if idx < len(timestamps) else pd.NaT
+        if pd.isna(timestamp):
+            continue
+        payload: Dict[str, object] = {}
+        for column, value in row.items():
+            if pd.isna(value):
+                continue
+            payload[column] = value
+        payload["dateutc"] = timestamp.tz_convert(timezone.utc) if timestamp.tzinfo else timestamp.tz_localize(timezone.utc)
+        if local_series is not None and idx < len(local_series):
+            local_value = local_series.iloc[idx]
+            if pd.notna(local_value):
+                payload["date"] = local_value
+        if mac:
+            payload.setdefault("mac", mac)
+        records.append(payload)
+    return records
+
+
+def _write_report(config: Dict, report: Dict) -> Path:
+    storage_cfg = config.get("storage", {})
+    root = Path(storage_cfg.get("root_dir", "./data"))
+    logs_dir = root / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%SZ")
+    path = logs_dir / f"import_{timestamp}.json"
+    path.write_text(json.dumps(report, indent=2))
+    return path
+
+
+def import_files(
+    paths: Iterable[Path],
+    *,
+    config: Dict,
+    storage: StorageManager,
+) -> Dict:
+    mac = config.get("ambient", {}).get("mac")
+    summaries: List[Dict] = []
+    total_inserted = 0
+    total_rows = 0
+    canonical_rows = 0
+    overall_start: Optional[pd.Timestamp] = None
+    overall_end: Optional[pd.Timestamp] = None
+
+    for path in paths:
+        df = _read_table(path)
+        records = _frame_to_records(df, mac=mac)
+        total_rows += len(df)
+        canonical = canonicalize_records(records, mac_hint=mac)
+        canonical_rows += len(canonical)
+        result = storage.upsert_canonical(canonical)
+        total_inserted += result.inserted
+        if result.start is not None:
+            overall_start = result.start if overall_start is None else min(overall_start, result.start)
+        if result.end is not None:
+            overall_end = result.end if overall_end is None else max(overall_end, result.end)
+        summaries.append(
+            {
+                "path": str(path),
+                "rows_read": len(df),
+                "rows_normalized": len(canonical),
+                "rows_inserted": result.inserted,
+                "time_start": result.start.isoformat() if result.start is not None else None,
+                "time_end": result.end.isoformat() if result.end is not None else None,
+            }
+        )
+        logger.info(
+            "Imported %s rows from %s (inserted %s new rows)",
+            len(df),
+            path,
+            result.inserted,
+        )
+
+    report = {
+        "files": summaries,
+        "total_rows": total_rows,
+        "total_normalized": canonical_rows,
+        "total_inserted": total_inserted,
+        "time_start": overall_start.isoformat() if overall_start is not None else None,
+        "time_end": overall_end.isoformat() if overall_end is not None else None,
+    }
+    report_path = _write_report(config, report)
+    report["report_path"] = str(report_path)
+    return report
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Import offline Ambient/Weather Underground exports")
+    parser.add_argument("paths", nargs="+", type=Path, help="CSV/XLSX files to import")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    config = ingest.load_config()
+    storage = ingest.get_storage_manager(config)
+    report = import_files(args.paths, config=config, storage=storage)
+    logger.info("Offline import complete: %s rows inserted", report["total_inserted"])
+    logger.info("Import report saved to %s", report["report_path"])
+
+
+if __name__ == "__main__":
+    main()
+

--- a/homesky/storage.py
+++ b/homesky/storage.py
@@ -1,0 +1,249 @@
+"""Shared persistence helpers for HomeSky data flows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence
+
+import pandas as pd
+from loguru import logger
+
+from utils.db import DatabaseManager
+from utils.derived import compute_all_derived
+
+
+EXCLUDED_KEYS: frozenset[str] = frozenset({
+    "lastData",
+    "raw",
+    "macAddress",
+    "macaddress",
+})
+
+
+@dataclass(slots=True)
+class StorageResult:
+    """Result metadata returned after persisting observations."""
+
+    inserted: int
+    start: Optional[pd.Timestamp]
+    end: Optional[pd.Timestamp]
+
+
+def _coerce_utc(value: object) -> Optional[pd.Timestamp]:
+    if value is None:
+        return None
+    try:
+        ts = pd.to_datetime(value, utc=True, errors="coerce")
+    except Exception:  # pragma: no cover - defensive guard
+        return None
+    if ts is None or (isinstance(ts, float) and pd.isna(ts)):
+        return None
+    if isinstance(ts, pd.Series):
+        ts = ts.iloc[0]
+    if isinstance(ts, pd.DatetimeIndex):
+        ts = ts[0]
+    if ts.tzinfo is None:
+        ts = ts.tz_localize("UTC")
+    else:
+        ts = ts.tz_convert("UTC")
+    return ts
+
+
+def _coerce_local(value: object) -> Optional[pd.Timestamp]:
+    if value is None:
+        return None
+    try:
+        ts = pd.to_datetime(value, errors="coerce")
+    except Exception:  # pragma: no cover - defensive guard
+        return None
+    if isinstance(ts, pd.Series):
+        ts = ts.iloc[0]
+    if isinstance(ts, pd.DatetimeIndex):
+        ts = ts[0]
+    if ts is None or (isinstance(ts, float) and pd.isna(ts)):
+        return None
+    return ts
+
+
+def _resolve_mac(candidate: dict, mac_hint: Optional[str]) -> Optional[str]:
+    for key in ("station_mac", "mac", "macAddress", "macaddress", "device_mac"):
+        value = candidate.get(key)
+        if value:
+            return str(value)
+    return mac_hint
+
+
+def _extract_timestamp_payload(payload: dict) -> Optional[pd.Timestamp]:
+    for key in (
+        "timestamp_utc",
+        "obs_time_utc",
+        "dateutc",
+        "time_utc",
+        "timestamp",
+        "datetime",
+    ):
+        if key in payload and payload.get(key) not in (None, ""):
+            ts = _coerce_utc(payload.get(key))
+            if ts is not None:
+                return ts
+    epoch_ms = payload.get("epoch_ms")
+    if epoch_ms:
+        try:
+            ts = pd.to_datetime(int(epoch_ms), unit="ms", utc=True)
+            return ts
+        except Exception:  # pragma: no cover - defensive guard
+            return None
+    epoch = payload.get("epoch")
+    if epoch:
+        try:
+            ts = pd.to_datetime(int(epoch), unit="s", utc=True)
+            return ts
+        except Exception:  # pragma: no cover - defensive guard
+            return None
+    return None
+
+
+def _extract_local_timestamp(payload: dict) -> Optional[pd.Timestamp]:
+    for key in ("timestamp_local", "obs_time_local", "date", "datetime_local"):
+        if key in payload and payload.get(key) not in (None, ""):
+            local = _coerce_local(payload.get(key))
+            if local is not None:
+                return local
+    return None
+
+
+def canonicalize_records(
+    records: Sequence[dict],
+    *,
+    mac_hint: Optional[str] = None,
+) -> pd.DataFrame:
+    """Return a canonical DataFrame suitable for persistence."""
+
+    canonical_rows: List[dict] = []
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        raw_payload = record.get("raw")
+        if not isinstance(raw_payload, dict):
+            raw_payload = {k: v for k, v in record.items() if k not in EXCLUDED_KEYS}
+        combined: dict = {**raw_payload, **record}
+        for key in EXCLUDED_KEYS:
+            combined.pop(key, None)
+        timestamp_utc = _extract_timestamp_payload({**raw_payload, **record})
+        mac_value = _resolve_mac({**raw_payload, **record}, mac_hint)
+        if timestamp_utc is None or not mac_value:
+            continue
+        timestamp_local = _extract_local_timestamp({**raw_payload, **record})
+        epoch_ms = record.get("epoch_ms") or raw_payload.get("epoch_ms")
+        if not epoch_ms:
+            epoch = record.get("epoch") or raw_payload.get("epoch")
+            if epoch:
+                try:
+                    epoch_ms = int(float(epoch) * 1000)
+                except (TypeError, ValueError):
+                    epoch_ms = None
+        if not epoch_ms:
+            epoch_ms = int(timestamp_utc.value // 1_000_000)
+        epoch_seconds = record.get("epoch") or raw_payload.get("epoch")
+        if not epoch_seconds:
+            epoch_seconds = int(epoch_ms // 1000)
+        canonical = dict(combined)
+        canonical["station_mac"] = mac_value
+        canonical["mac"] = mac_value
+        canonical["timestamp_utc"] = timestamp_utc
+        canonical["timestamp_local"] = timestamp_local
+        canonical["epoch"] = epoch_seconds
+        canonical["epoch_ms"] = epoch_ms
+        canonical["raw"] = raw_payload
+        canonical_rows.append(canonical)
+
+    if not canonical_rows:
+        return pd.DataFrame()
+
+    frame = pd.DataFrame(canonical_rows)
+    frame = frame.dropna(subset=["timestamp_utc", "station_mac"])
+    if frame.empty:
+        return frame
+    frame["timestamp_utc"] = pd.to_datetime(frame["timestamp_utc"], utc=True, errors="coerce")
+    frame = frame.dropna(subset=["timestamp_utc"])
+    if frame.empty:
+        return frame
+    frame = frame.sort_values("timestamp_utc")
+    frame = frame.drop_duplicates(subset=["station_mac", "epoch_ms"], keep="last")
+    frame = frame.set_index("timestamp_utc")
+    frame.index.name = "timestamp_utc"
+    return frame
+
+
+class StorageManager:
+    """Coordinate persistence of weather observations."""
+
+    def __init__(
+        self,
+        sqlite_path: Path | str,
+        parquet_path: Path | str,
+        *,
+        config: Optional[dict] = None,
+    ) -> None:
+        self.sqlite_path = Path(sqlite_path)
+        self.parquet_path = Path(parquet_path)
+        self.config = config or {}
+        self._db = DatabaseManager(self.sqlite_path, self.parquet_path)
+
+    @classmethod
+    def from_config(cls, config: dict) -> "StorageManager":
+        storage_cfg = config.get("storage", {})
+        return cls(
+            storage_cfg.get("sqlite_path", "./data/homesky.sqlite"),
+            storage_cfg.get("parquet_path", "./data/homesky.parquet"),
+            config=config,
+        )
+
+    @property
+    def database(self) -> DatabaseManager:
+        return self._db
+
+    def upsert_canonical(
+        self,
+        canonical: pd.DataFrame,
+        *,
+        compute_derived: bool = True,
+    ) -> StorageResult:
+        if canonical.empty:
+            return StorageResult(0, None, None)
+        rows = canonical.reset_index().to_dict(orient="records")
+        inserted = self._db.insert_observations(rows)
+        if inserted and compute_derived:
+            base = canonical.drop(columns=["raw"], errors="ignore")
+            try:
+                enriched = compute_all_derived(base, self.config)
+            except Exception as exc:  # pragma: no cover - do not block persistence
+                logger.warning("Failed to compute derived metrics: {}", exc)
+            else:
+                self._db.append_parquet(enriched)
+        start = canonical.index.min() if inserted else None
+        end = canonical.index.max() if inserted else None
+        return StorageResult(inserted, start, end)
+
+    def upsert_dataframe(
+        self,
+        frame: pd.DataFrame,
+        *,
+        mac_hint: Optional[str] = None,
+        compute_derived: bool = True,
+    ) -> StorageResult:
+        if frame.empty:
+            return StorageResult(0, None, None)
+        canonical = canonicalize_records(frame.to_dict(orient="records"), mac_hint=mac_hint)
+        if canonical.empty:
+            return StorageResult(0, None, None)
+        return self.upsert_canonical(canonical, compute_derived=compute_derived)
+
+
+__all__ = [
+    "StorageManager",
+    "StorageResult",
+    "canonicalize_records",
+]
+

--- a/homesky/utils/__init__.py
+++ b/homesky/utils/__init__.py
@@ -1,14 +1,15 @@
 """Utility helpers for HomeSky."""
 
-from .ambient import AmbientClient, get_devices, fetch_latest_observations
+from .ambient import AmbientClient, fetch_latest_observations, get_devices, get_device_data
 from .db import DatabaseManager, ensure_schema
 from .derived import compute_all_derived, register_derived_metric
 from .theming import get_theme, load_typography
 
 __all__ = [
     "AmbientClient",
-    "get_devices",
     "fetch_latest_observations",
+    "get_devices",
+    "get_device_data",
     "DatabaseManager",
     "ensure_schema",
     "compute_all_derived",

--- a/homesky/utils/ambient.py
+++ b/homesky/utils/ambient.py
@@ -1,36 +1,69 @@
-"""Ambient Weather Network client helpers."""
+"""Ambient Weather Network API helpers with rate limiting and backoff."""
 
 from __future__ import annotations
 
+import random
+import threading
 import time
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, List, Optional, Set, Tuple
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
 
 import requests
 from loguru import logger
 
 BASE_URL = "https://api.ambientweather.net/v1"
 
+_RATE_LOCK = threading.Lock()
+_LAST_REQUEST_TS = 0.0
+_MIN_REQUEST_INTERVAL = 1.0
+_JITTER_RANGE = (0.0, 0.2)
+
 
 class AmbientAPIError(RuntimeError):
-    """Raised when the Ambient Weather Network API returns an error."""
+    """Raised when the Ambient Weather API returns an error payload."""
+
+
+def _throttle() -> None:
+    global _LAST_REQUEST_TS
+    with _RATE_LOCK:
+        now = time.monotonic()
+        target = _LAST_REQUEST_TS + _MIN_REQUEST_INTERVAL
+        wait_seconds = max(0.0, target - now)
+        if wait_seconds > 0:
+            time.sleep(wait_seconds)
+        jitter = random.uniform(*_JITTER_RANGE)
+        if jitter > 0:
+            time.sleep(jitter)
+        _LAST_REQUEST_TS = time.monotonic()
+
+
+def _should_retry(response: requests.Response) -> bool:
+    if response.status_code == 429:
+        return True
+    if 500 <= response.status_code < 600:
+        return True
+    return False
 
 
 @dataclass(slots=True)
 class AmbientClient:
-    """Thin wrapper around the Ambient Weather Network REST API."""
+    """Thin wrapper around the Ambient Weather Network API."""
 
     api_key: str
     application_key: str
     mac: Optional[str] = None
     session: Optional[requests.Session] = None
-    retries: int = 3
-    backoff: float = 5.0
+    max_retries: int = 4
 
-    def _request(self, path: str, params: Optional[Dict[str, Any]] = None) -> Any:
+    def _request(
+        self,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> Any:
         if not self.api_key or not self.application_key:
-            raise AmbientAPIError("API key and application key are required")
+            raise AmbientAPIError("Ambient API credentials are required")
 
         payload = {
             "apiKey": self.api_key,
@@ -41,181 +74,131 @@ class AmbientClient:
         if self.mac:
             payload.setdefault("macAddress", self.mac)
 
-        session = self.session or requests.Session()
         attempt = 0
+        session = self.session or requests.Session()
         while True:
             attempt += 1
+            _throttle()
             try:
                 response = session.get(f"{BASE_URL}/{path}", params=payload, timeout=30)
-                if response.status_code >= 400:
-                    raise AmbientAPIError(
-                        f"Ambient API error {response.status_code}: {response.text}"
-                    )
-                return response.json()
-            except (requests.RequestException, AmbientAPIError) as exc:  # pragma: no cover
-                if attempt >= self.retries:
+            except requests.RequestException as exc:
+                if attempt >= self.max_retries:
                     logger.error("Ambient API request failed after {} attempts", attempt)
-                    raise
-                sleep_for = self.backoff * attempt
+                    raise AmbientAPIError(str(exc)) from exc
+                delay = min(8.0, 2 ** (attempt - 1))
+                sleep_for = delay + random.uniform(0, 0.5)
                 logger.warning(
-                    "Ambient API request failed (attempt {}/{}): {}; retrying in {:.1f}s",
+                    "Ambient API request errored (attempt {}/{}): {}; retrying in {:.1f}s",
                     attempt,
-                    self.retries,
+                    self.max_retries,
                     exc,
                     sleep_for,
                 )
                 time.sleep(sleep_for)
+                continue
+
+            if response.ok:
+                try:
+                    return response.json()
+                except ValueError as exc:  # pragma: no cover - unexpected payload
+                    logger.error("Ambient API returned invalid JSON: {}", exc)
+                    raise AmbientAPIError("Invalid JSON response from Ambient API") from exc
+
+            if not _should_retry(response) or attempt >= self.max_retries:
+                logger.error(
+                    "Ambient API error %s after %s attempts: %s",
+                    response.status_code,
+                    attempt,
+                    response.text,
+                )
+                raise AmbientAPIError(
+                    f"Ambient API error {response.status_code}: {response.text}"
+                )
+
+            delay = min(8.0, 2 ** (attempt - 1))
+            sleep_for = delay + random.uniform(0, 0.5)
+            logger.warning(
+                "Ambient API rate limited/errored (attempt {}/{}); retrying in {:.1f}s",
+                attempt,
+                self.max_retries,
+                sleep_for,
+            )
+            time.sleep(sleep_for)
 
     def get_devices(self) -> List[Dict[str, Any]]:
-        """Return the list of devices bound to the API keys."""
-
-        devices = self._request("devices")
-        if not isinstance(devices, list):
-            raise AmbientAPIError("Unexpected devices payload")
+        payload = self._request("devices")
+        if not isinstance(payload, list):
+            raise AmbientAPIError("Unexpected response when listing devices")
         if self.mac:
-            devices = [device for device in devices if device.get("macAddress") == self.mac]
-        logger.debug("Fetched {} devices from Ambient Weather", len(devices))
-        return devices
+            return [row for row in payload if row.get("macAddress") == self.mac]
+        return payload
 
-    def get_device_data(self, limit: int = 288) -> List[Dict[str, Any]]:
-        """Fetch recent observations for the configured device(s)."""
-
+    def get_device_data(
+        self,
+        *,
+        mac: Optional[str] = None,
+        end_dt: Optional[datetime] = None,
+        limit: int = 288,
+        tz: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        mac_to_use = mac or self.mac
+        if not mac_to_use:
+            payload = self._request("devices", params={"limit": limit})
+            if not isinstance(payload, list):
+                raise AmbientAPIError("Unexpected payload when fetching device data")
+            return payload
         params: Dict[str, Any] = {"limit": limit}
-        data = self._request("devices", params=params)
-        if not isinstance(data, list):
-            raise AmbientAPIError("Unexpected observations payload")
-        logger.debug("Fetched {} observation rows", len(data))
-        return data
+        if end_dt:
+            if end_dt.tzinfo is None:
+                end_dt = end_dt.replace(tzinfo=timezone.utc)
+            params["endDate"] = end_dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        if tz:
+            params["tz"] = tz
+        payload = self._request(f"devices/{mac_to_use}", params=params)
+        if not isinstance(payload, list):
+            raise AmbientAPIError("Unexpected payload when fetching device data")
+        return payload
 
 
-def get_devices(api_key: str, app_key: str, mac: str | None = None) -> List[Dict[str, Any]]:
-    """Convenience function to retrieve device metadata."""
-
-    client = AmbientClient(api_key=api_key, application_key=app_key, mac=mac)
+def get_devices(
+    api_key: str,
+    application_key: str,
+    *,
+    mac: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    client = AmbientClient(api_key=api_key, application_key=application_key, mac=mac)
     return client.get_devices()
+
+
+def get_device_data(
+    api_key: str,
+    application_key: str,
+    *,
+    mac: Optional[str],
+    end_dt: Optional[datetime] = None,
+    limit: int = 288,
+    tz: Optional[str] = None,
+) -> List[Dict[str, Any]]:
+    client = AmbientClient(api_key=api_key, application_key=application_key, mac=mac)
+    return client.get_device_data(mac=mac, end_dt=end_dt, limit=limit, tz=tz)
 
 
 def fetch_latest_observations(
     api_key: str,
-    app_key: str,
-    mac: str | None = None,
+    application_key: str,
+    *,
+    mac: Optional[str] = None,
     limit: int = 288,
 ) -> List[Dict[str, Any]]:
-    """Fetch latest observations for downstream ingestion."""
-
-    client = AmbientClient(api_key=api_key, application_key=app_key, mac=mac)
-    return client.get_device_data(limit=limit)
+    client = AmbientClient(api_key=api_key, application_key=application_key, mac=mac)
+    return client.get_device_data(mac=mac, limit=limit)
 
 
-def _parse_dateutc(value: Any) -> Optional[datetime]:
-    if value is None:
-        return None
-    if isinstance(value, (int, float)):
-        try:
-            return datetime.fromtimestamp(float(value) / 1000.0, tz=timezone.utc)
-        except (OSError, OverflowError, ValueError):
-            return None
-    if isinstance(value, str):
-        text = value.strip()
-        if not text:
-            return None
-        try:
-            numeric = float(text)
-        except ValueError:
-            numeric = None
-        if numeric is not None:
-            try:
-                return datetime.fromtimestamp(numeric / 1000.0, tz=timezone.utc)
-            except (OSError, OverflowError, ValueError):
-                pass
-        iso_candidate = text
-        if iso_candidate.endswith("Z"):
-            iso_candidate = iso_candidate[:-1] + "+00:00"
-        try:
-            dt = datetime.fromisoformat(iso_candidate)
-            if dt.tzinfo is None:
-                dt = dt.replace(tzinfo=timezone.utc)
-            return dt.astimezone(timezone.utc)
-        except ValueError:
-            pass
-        for fmt in ("%Y-%m-%d %H:%M:%S", "%m/%d/%Y %H:%M:%S"):
-            try:
-                dt = datetime.strptime(text, fmt)
-                return dt.replace(tzinfo=timezone.utc)
-            except ValueError:
-                continue
-    return None
+__all__ = [
+    "AmbientAPIError",
+    "AmbientClient",
+    "get_devices",
+    "get_device_data",
+    "fetch_latest_observations",
+]
 
-
-def fetch_history(
-    api_key: str,
-    app_key: str,
-    mac: str | None,
-    *,
-    hours: int = 24,
-    tz: str = "America/New_York",
-    page_size: int = 288,
-) -> List[Dict[str, Any]]:
-    """Fetch historical observations spanning ``hours`` back from now."""
-
-    if hours <= 0:
-        return []
-    if not mac:
-        raise ValueError("A device MAC address is required to fetch history")
-
-    end_cursor = datetime.now(timezone.utc)
-    target_start = end_cursor - timedelta(hours=hours)
-    seen: Set[Tuple[str, str]] = set()
-    results: List[Dict[str, Any]] = []
-
-    with requests.Session() as session:
-        while True:
-            remaining_hours = max(
-                1.0, (end_cursor - target_start).total_seconds() / 3600.0
-            )
-            approx_samples = max(1, int(remaining_hours * 12))
-            limit = max(1, min(page_size, approx_samples))
-            params = {
-                "apiKey": api_key,
-                "applicationKey": app_key,
-                "limit": limit,
-                "endDate": end_cursor.strftime("%Y-%m-%d %H:%M:%S"),
-                "tz": tz,
-            }
-            response = session.get(f"{BASE_URL}/devices/{mac}", params=params, timeout=30)
-            if response.status_code >= 400:
-                raise AmbientAPIError(
-                    f"Ambient API error {response.status_code}: {response.text}"
-                )
-            payload = response.json()
-            if not isinstance(payload, list):
-                raise AmbientAPIError("Unexpected history payload")
-            if not payload:
-                break
-
-            oldest_dt: Optional[datetime] = None
-            unique_batch: List[Dict[str, Any]] = []
-            for item in payload:
-                if not isinstance(item, dict):
-                    continue
-                dt = _parse_dateutc(item.get("dateutc"))
-                if dt and (oldest_dt is None or dt < oldest_dt):
-                    oldest_dt = dt
-                key = (str(item.get("dateutc")), str(item.get("macAddress") or mac))
-                if key in seen:
-                    continue
-                seen.add(key)
-                unique_batch.append(item)
-
-            results.extend(unique_batch)
-
-            if not oldest_dt:
-                break
-            if oldest_dt <= target_start:
-                break
-            if oldest_dt >= end_cursor:
-                break
-
-            end_cursor = oldest_dt - timedelta(seconds=1)
-
-    return results


### PR DESCRIPTION
## Summary
- add a shared storage manager with canonical observation schema and epoch-based dedupe across SQLite and Parquet
- enforce Ambient Weather API throttling with exponential backoff and checkpointed backfill loops
- provide GUI/CLI offline import workflows, new launcher controls, and dashboard telemetry updates

## Testing
- `python -m compileall homesky weather_lake`


------
https://chatgpt.com/codex/tasks/task_e_68e282ec6294832e9eb74d74334d34b3