### PR TITLE
feat: auto-sync streamlit dashboard on launch

### DIFF
--- a/homesky/config.example.toml
+++ b/homesky/config.example.toml
@@ -31,6 +31,7 @@ enable_wind_run = true
 [ingest]
 deduplicate_by_timestamp = true
 drop_implausible_values = true
+auto_sync_on_launch = true
 log_path = "./data/logs/ingest.log"
 log_rotate_days = 14
 max_retries = 3

--- a/homesky/ingest.py
+++ b/homesky/ingest.py
@@ -344,6 +344,81 @@ def filter_new_canonical(
     return df[df["epoch_ms"] > latest]
 
 
+def sync_new(
+    config: Optional[Dict] = None,
+    *,
+    client: Optional[AmbientClient] = None,
+    storage: Optional[StorageManager] = None,
+) -> Dict[str, object]:
+    """Fetch and persist observations newer than the latest stored timestamp."""
+
+    cfg = config or load_config()
+    storage_manager = storage or get_storage_manager(cfg)
+    ambient_cfg = cfg.get("ambient", {})
+    ingest_cfg = cfg.get("ingest", {})
+
+    mac = ambient_cfg.get("mac") or None
+    since_ts = storage_manager.database.max_observation_time(mac)
+    since_value = None
+    if since_ts is not None and not pd.isna(since_ts):
+        since_value = since_ts.to_pydatetime()
+
+    client = client or AmbientClient(
+        api_key=ambient_cfg.get("api_key"),
+        application_key=ambient_cfg.get("application_key"),
+        mac=mac,
+    )
+
+    limit = int(ingest_cfg.get("fetch_limit", 288) or 288)
+    records = client.get_device_data(mac=mac, limit=limit)
+    if not records:
+        log.info("sync_new: Ambient API returned no records to process")
+        return {"added": 0, "since": since_value, "until": since_value, "skipped": 0}
+
+    raw_count = len(records)
+    frame = _history_records_to_frame(records, mac)
+    if frame.empty:
+        log.info("sync_new: fetched payload contained no valid observations")
+        return {"added": 0, "since": since_value, "until": since_value, "skipped": raw_count}
+
+    if ingest_cfg.get("drop_implausible_values", True):
+        frame = drop_implausible(frame)
+
+    canonical = canonicalize_records(
+        frame.reset_index().to_dict(orient="records"), mac_hint=mac
+    )
+    if canonical.empty:
+        log.info("sync_new: no canonical rows available after preprocessing")
+        return {"added": 0, "since": since_value, "until": since_value, "skipped": raw_count}
+
+    canonical = filter_new_canonical(
+        canonical,
+        storage_manager,
+        mac,
+        enabled=ingest_cfg.get("deduplicate_by_timestamp", True),
+    )
+    if canonical.empty:
+        log.info("sync_new: all fetched rows already present in the database")
+        return {"added": 0, "since": since_value, "until": since_value, "skipped": raw_count}
+
+    result = storage_manager.upsert_canonical(canonical)
+    added = int(result.inserted)
+    until_ts = result.end.to_pydatetime() if result.end is not None else since_value
+    skipped = max(raw_count - added, 0)
+
+    if added:
+        log.info(
+            "sync_new: added %s new rows spanning %s to %s",
+            added,
+            result.start,
+            result.end,
+        )
+    else:
+        log.info("sync_new: no new rows persisted after storage layer checks")
+
+    return {"added": added, "since": since_value, "until": until_ts, "skipped": skipped}
+
+
 def detect_cadence_seconds(df: pd.DataFrame) -> int:
     if df.empty or "epoch" not in df:
         return 60


### PR DESCRIPTION
## Summary
- add a package-aware import shim to the Streamlit dashboard so it runs both as a package and as a script
- introduce ingest.sync_new to fetch and persist only new observations and call it automatically when the dashboard starts
- tuck the manual backfill actions into a guarded "Advanced ingestion" expander and document the auto-sync flag in config.example.toml

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e45e8ab1b8832ea365e60e6145cc77